### PR TITLE
Fixes #311 (Removal of model doesn't check if it's in use by a policy)

### DIFF
--- a/web/api/api_image_v1.rb
+++ b/web/api/api_image_v1.rb
@@ -259,7 +259,7 @@ module Hanlon
                 # Use the Engine instance to remove the selected image from the database
                 engine = ProjectHanlon::Engine.instance
                 begin
-                  engine.remove_image(image)
+                  raise ProjectHanlon::Error::Slice::CouldNotRemove, "Could not remove Image [#{image_uuid}]" unless engine.remove_image(image)
                 rescue RuntimeError => e
                   raise ProjectHanlon::Error::Slice::InternalError, e.message
                 rescue Exception => e

--- a/web/api/api_image_v1.rb
+++ b/web/api/api_image_v1.rb
@@ -258,9 +258,8 @@ module Hanlon
                 raise ProjectHanlon::Error::Slice::InvalidUUID, "Cannot Find Image with UUID: [#{image_uuid}]" unless image && (image.class != Array || image.length > 0)
                 # Use the Engine instance to remove the selected image from the database
                 engine = ProjectHanlon::Engine.instance
-                return_status = false
                 begin
-                  return_status = engine.remove_image(image)
+                  engine.remove_image(image)
                 rescue RuntimeError => e
                   raise ProjectHanlon::Error::Slice::InternalError, e.message
                 rescue Exception => e

--- a/web/api/api_model_v1.rb
+++ b/web/api/api_model_v1.rb
@@ -265,7 +265,16 @@ module Hanlon
               model_uuid = params[:uuid]
               model = SLICE_REF.get_object("model_with_uuid", :model, model_uuid)
               raise ProjectHanlon::Error::Slice::InvalidUUID, "Cannot Find Model with UUID: [#{model_uuid}]" unless model && (model.class != Array || model.length > 0)
-              raise ProjectHanlon::Error::Slice::CouldNotRemove, "Could not remove Model [#{model.uuid}]" unless get_data_ref.delete_object(model)
+              # Use the Engine instance to remove the selected model from the database
+              engine = ProjectHanlon::Engine.instance
+              begin
+                engine.remove_model(model)
+              rescue RuntimeError => e
+                raise ProjectHanlon::Error::Slice::InternalError, e.message
+              rescue Exception => e
+                # if got to here, then the Engine raised an exception
+                raise ProjectHanlon::Error::Slice::CouldNotRemove, e.message
+              end
               slice_success_response(SLICE_REF, :remove_model_by_uuid, "Model [#{model.uuid}] removed", :success_type => :removed)
             end     # end DELETE /model/{uuid}
 

--- a/web/api/api_model_v1.rb
+++ b/web/api/api_model_v1.rb
@@ -269,6 +269,7 @@ module Hanlon
               engine = ProjectHanlon::Engine.instance
               begin
                 engine.remove_model(model)
+                raise ProjectHanlon::Error::Slice::CouldNotRemove, "Could not remove Model [#{model.uuid}]" unless engine.remove_model(model)
               rescue RuntimeError => e
                 raise ProjectHanlon::Error::Slice::InternalError, e.message
               rescue Exception => e


### PR DESCRIPTION
This pull request adds code to check and see if a model is in use with a policy before removing the model. If it is in use with a policy, then an error message is returned and the model is not removed (as is the case with removal of images that are in use with a model, removing a model that is in use with a policy can create an error condition where policies exist that reference non-existent models). While making the modifications to support this additional check in the model DELETE method, the code for the image slice (in the Engine class) was also modified slightly so that (like the code in the new `remove_model` method we added to this class) the UUIDs of **all** of the models that use a given image are mentioned in the error message that is returned when trying to remove an image that is used by one or more models. Previously, only the UUID of first model would be returned as part of that message; leading to a potential "whack-a-mole" type scenario where you removed the model that used that image, only to find out when you tried to remove the image again that there is a second (and a third, and a fourth, etc.) model that uses the same image...