### PR TITLE
Adds Windows support to the image slice

### DIFF
--- a/core/image_service.rb
+++ b/core/image_service.rb
@@ -1,6 +1,7 @@
 require "image_service/base"
 require "image_service/microkernel"
 require "image_service/os_install"
+require "image_service/windows_install"
 require "image_service/vmware_hypervisor"
 require "image_service/xenserver_hypervisor"
 

--- a/core/image_service/base.rb
+++ b/core/image_service/base.rb
@@ -233,24 +233,23 @@ module ProjectHanlon
       end
 
       def print_header
-        return "UUID", "Type", "ISO Filename", "Status"
+        return "UUID", "Type", "Name/Filename", "Status"
       end
 
       def print_items
-        return @uuid, @description, @filename, "#{@image_status ? "Valid".green : "Invalid - #{@image_status_message}".red}"
+        return @uuid, @description, get_name, "#{@image_status ? "Valid".green : "Invalid - #{@image_status_message}".red}"
       end
 
       def print_item_header
-        return "UUID", "Type", "ISO Filename", "Status"
+        return "UUID", "Type", "Name/Filename", "Status"
       end
 
       def print_item
+        return @uuid, @description, get_name,  "#{@image_status ? "Valid".green : "Invalid - #{@image_status_message}".red}"
+      end
 
-        #set_lcl_image_path(ProjectHanlon.config.image_path)
-        #success, message = verify(@_lcl_image_path)
-        #return @uuid, @description, @filename, image_path.to_s, "#{success ? "Valid".green : "Broken/Missing".red}"
-
-        return @uuid, @description, @filename,  "#{@image_status ? "Valid".green : "Invalid - #{@image_status_message}".red}"
+      def get_name
+        @os_name ? @os_name : @filename
       end
 
       def line_color

--- a/core/image_service/microkernel.rb
+++ b/core/image_service/microkernel.rb
@@ -23,22 +23,20 @@ module ProjectHanlon
         from_hash(hash) unless hash == nil
       end
 
-      def add(src_image_path, lcl_image_path, extra)
+      def add(src_image_path, lcl_image_path)
         # Add the iso to the image svc storage
 
         begin
-          resp = super(src_image_path, lcl_image_path, extra)
+          resp = super(src_image_path, lcl_image_path)
           if resp[0]
             success, result_string = verify(lcl_image_path)
             unless success
               logger.error result_string
               return [false, result_string]
             end
-            return resp
-          else
-            resp
           end
-          rescue => e
+          resp
+        rescue => e
             #logger.error e.message
             logger.log_exception e
             raise ProjectHanlon::Error::Slice::InternalError, e.message

--- a/core/image_service/microkernel.rb
+++ b/core/image_service/microkernel.rb
@@ -23,11 +23,11 @@ module ProjectHanlon
         from_hash(hash) unless hash == nil
       end
 
-      def add(src_image_path, lcl_image_path)
+      def add(src_image_path, lcl_image_path, extra = {})
         # Add the iso to the image svc storage
 
         begin
-          resp = super(src_image_path, lcl_image_path)
+          resp = super(src_image_path, lcl_image_path, extra)
           if resp[0]
             success, result_string = verify(lcl_image_path)
             unless success

--- a/core/image_service/os_install.rb
+++ b/core/image_service/os_install.rb
@@ -16,13 +16,12 @@ module ProjectHanlon
 
       def add(src_image_path, lcl_image_path, extra)
         begin
-          resp = super(src_image_path, lcl_image_path, extra)
+          resp = super(src_image_path, lcl_image_path)
           if resp[0]
             @os_name = extra[:os_name]
             @os_version = extra[:os_version]
-          else
-            resp
           end
+          resp
         rescue => e
           logger.error e.message
           return [false, e.message]

--- a/core/image_service/os_install.rb
+++ b/core/image_service/os_install.rb
@@ -16,7 +16,7 @@ module ProjectHanlon
 
       def add(src_image_path, lcl_image_path, extra)
         begin
-          resp = super(src_image_path, lcl_image_path)
+          resp = super(src_image_path, lcl_image_path, extra)
           if resp[0]
             @os_name = extra[:os_name]
             @os_version = extra[:os_version]

--- a/core/image_service/vmware_hypervisor.rb
+++ b/core/image_service/vmware_hypervisor.rb
@@ -14,19 +14,17 @@ module ProjectHanlon
         from_hash(hash) unless hash == nil
       end
 
-      def add(src_image_path, lcl_image_path, extra)
+      def add(src_image_path, lcl_image_path)
         begin
-          resp = super(src_image_path, lcl_image_path, extra)
+          resp = super(src_image_path, lcl_image_path)
           if resp[0]
             success, result_string = verify(lcl_image_path)
             unless success
               logger.error result_string
               return [false, result_string]
             end
-            return resp
-          else
-            resp
           end
+          resp
         rescue => e
           logger.error e.message
           return [false, e.message]

--- a/core/image_service/vmware_hypervisor.rb
+++ b/core/image_service/vmware_hypervisor.rb
@@ -14,9 +14,9 @@ module ProjectHanlon
         from_hash(hash) unless hash == nil
       end
 
-      def add(src_image_path, lcl_image_path)
+      def add(src_image_path, lcl_image_path, extra = {})
         begin
-          resp = super(src_image_path, lcl_image_path)
+          resp = super(src_image_path, lcl_image_path, extra)
           if resp[0]
             success, result_string = verify(lcl_image_path)
             unless success

--- a/core/image_service/windows_install.rb
+++ b/core/image_service/windows_install.rb
@@ -19,7 +19,7 @@ module ProjectHanlon
         begin
           # for Windows ISOs, the 'fuseiso' command will not work so we have to restrict the
           # supported methods to only support the 'mount' command
-          resp = super(src_image_path, lcl_image_path, { :verify_copy => false, :supported_methods => ['mount'] })
+          resp = super(src_image_path, lcl_image_path, { :verify_copy => false, :supported_methods => ['7z', 'mount'] })
           if resp[0]
             @os_name = "Windows (Base Image)"
             @wim_index = 0

--- a/core/image_service/windows_install.rb
+++ b/core/image_service/windows_install.rb
@@ -1,0 +1,63 @@
+module ProjectHanlon
+  module ImageService
+    # Image construct for generic Operating System install ISOs
+    class WindowsInstall < ProjectHanlon::ImageService::Base
+
+      attr_accessor :os_name
+      attr_accessor :os_version
+
+      def initialize(hash)
+        super(hash)
+        @description = "Windows Install"
+        @path_prefix = "windows"
+        @hidden = false
+        from_hash(hash) unless hash == nil
+      end
+
+      def add(src_image_path, lcl_image_path)
+        begin
+          # for Windows ISOs, the 'fuseiso' command will not work so we have to restrict the
+          # supported methods to only support the 'mount' command
+          resp = super(src_image_path, lcl_image_path, { :verify_copy => false, :supported_methods => ['mount'] })
+          if resp[0]
+            # TODO: replace this with code that adds in images for each entry in the install.wim file
+            # (with names for each that are also extracted from that same file)
+            @os_name = "Windows (Generic)"
+          end
+          resp
+        rescue => e
+          logger.error e.message
+          return [false, e.message]
+        end
+      end
+
+      # TODO: override the remove so that it supports 'removal by reference'
+      # only when the last reference to the underlying directory is removed
+      # should the underlying directory be removed???
+
+      def verify(lcl_image_path)
+        # check to make sure that the hashes match (of the file list
+        # extracted and the file list from the ISO)
+        # is_valid, result = super(lcl_image_path)
+        # unless is_valid
+        #   return [false, result]
+        # end
+
+        # For Windows images, the only really important thing is that we
+        # can find the 'install.wim' file once the image is unpacked
+        [true, '']
+      end
+
+      def print_item_header
+        # super.push "OS Name", "OS Version"
+        super.push "OS Name", "OS Version"
+      end
+
+      def print_item
+        # super.push @os_name.to_s, @os_version.to_s
+        super.push @os_name.to_s, @os_version.to_s
+      end
+
+    end
+  end
+end

--- a/core/image_service/windows_install.rb
+++ b/core/image_service/windows_install.rb
@@ -4,7 +4,8 @@ module ProjectHanlon
     class WindowsInstall < ProjectHanlon::ImageService::Base
 
       attr_accessor :os_name
-      attr_accessor :os_version
+      attr_accessor :wim_index
+      attr_accessor :base_image_uuid
 
       def initialize(hash)
         super(hash)
@@ -20,9 +21,10 @@ module ProjectHanlon
           # supported methods to only support the 'mount' command
           resp = super(src_image_path, lcl_image_path, { :verify_copy => false, :supported_methods => ['mount'] })
           if resp[0]
-            # TODO: replace this with code that adds in images for each entry in the install.wim file
-            # (with names for each that are also extracted from that same file)
-            @os_name = "Windows (Generic)"
+            @os_name = "Windows (Base Image)"
+            @wim_index = 0
+            @base_image_uuid = @uuid
+            @hidden = true
           end
           resp
         rescue => e
@@ -49,13 +51,11 @@ module ProjectHanlon
       end
 
       def print_item_header
-        # super.push "OS Name", "OS Version"
-        super.push "OS Name", "OS Version"
+        super.push "OS Name", "WIM Index", "Base Image"
       end
 
       def print_item
-        # super.push @os_name.to_s, @os_version.to_s
-        super.push @os_name.to_s, @os_version.to_s
+        super.push @os_name, @wim_index.to_s, @base_image_uuid
       end
 
     end

--- a/core/image_service/xenserver_hypervisor.rb
+++ b/core/image_service/xenserver_hypervisor.rb
@@ -13,9 +13,9 @@ module ProjectHanlon
         from_hash(hash) unless hash == nil
       end
 
-      def add(src_image_path, lcl_image_path)
+      def add(src_image_path, lcl_image_path, extra = {})
         begin
-          resp = super(src_image_path, lcl_image_path)
+          resp = super(src_image_path, lcl_image_path, extra)
           if resp[0]
             unless verify(lcl_image_path)
               logger.error "Missing metadata"

--- a/core/image_service/xenserver_hypervisor.rb
+++ b/core/image_service/xenserver_hypervisor.rb
@@ -13,18 +13,16 @@ module ProjectHanlon
         from_hash(hash) unless hash == nil
       end
 
-      def add(src_image_path, lcl_image_path, extra)
+      def add(src_image_path, lcl_image_path)
         begin
-          resp = super(src_image_path, lcl_image_path, extra)
+          resp = super(src_image_path, lcl_image_path)
           if resp[0]
             unless verify(lcl_image_path)
               logger.error "Missing metadata"
               return [false, "Missing metadata"]
             end
-            return resp
-          else
-            resp
           end
+          resp
         rescue => e
           logger.error e.message
           return [false, e.message]

--- a/core/model/ubuntu.rb
+++ b/core/model/ubuntu.rb
@@ -237,7 +237,7 @@ module ProjectHanlon
 
       def os_boot_script(policy_uuid)
         @result = "Replied with os boot script"
-        filepath = ('os_boot')
+        filepath = template_filepath('os_boot')
         ERB.new(File.read(filepath)).result(binding)
       end
 

--- a/core/model/ubuntu.rb
+++ b/core/model/ubuntu.rb
@@ -237,7 +237,7 @@ module ProjectHanlon
 
       def os_boot_script(policy_uuid)
         @result = "Replied with os boot script"
-        filepath = template_filepath('os_boot')
+        filepath = ('os_boot')
         ERB.new(File.read(filepath)).result(binding)
       end
 

--- a/core/slice/image.rb
+++ b/core/slice/image.rb
@@ -138,11 +138,11 @@ module ProjectHanlon
         end
         puts "Image Slice: used to add, view, and remove Images.".red
         puts "Image Commands:".yellow
-        puts "\thanlon image [get] [all]         " + "View all images (detailed list)".yellow
-        puts "\thanlon image [get] (UUID)        " + "View details of specified image".yellow
-        puts "\thanlon image add (options...)    " + "Add a new image to the system".yellow
-        puts "\thanlon image remove (UUID)       " + "Remove existing image from the system".yellow
-        puts "\thanlon image --help|-h           " + "Display this screen".yellow
+        puts "\thanlon image [get] [all] [--hidden,-i]    " + "View all images (detailed list)".yellow
+        puts "\thanlon image [get] (UUID)                 " + "View details of specified image".yellow
+        puts "\thanlon image add (options...)             " + "Add a new image to the system".yellow
+        puts "\thanlon image remove (UUID)                " + "Remove existing image from the system".yellow
+        puts "\thanlon image --help|-h                    " + "Display this screen".yellow
       end
 
       #Lists details for all images

--- a/core/slice/image.rb
+++ b/core/slice/image.rb
@@ -32,6 +32,11 @@ module ProjectHanlon
                 :classname => "ProjectHanlon::ImageService::OSInstall",
                 :method => "add_os"
             },
+            :win =>        {
+                :desc => "Windows Install ISO",
+                :classname => "ProjectHanlon::ImageService::WindowsInstall",
+                :method => "add_win"
+            },
             :esxi =>      {
                 :desc => "VMware Hypervisor ISO",
                 :classname => "ProjectHanlon::ImageService::VMwareHypervisor",
@@ -69,7 +74,7 @@ module ProjectHanlon
                   :default     => nil,
                   :short_form  => '-t',
                   :long_form   => '--type TYPE',
-                  :description => 'The type of image (mk, os, esxi, or xenserver)',
+                  :description => 'The type of image (mk, os, win, esxi, or xenserver)',
                   :uuid_is     => 'not_allowed',
                   :required    => true
                 },
@@ -201,15 +206,19 @@ module ProjectHanlon
       # utility methods (used to add various types of images)
 
       def add_mk(new_image, iso_path, image_path)
-        new_image.add(iso_path, image_path, nil)
+        new_image.add(iso_path, image_path)
       end
 
       def add_esxi(new_image, iso_path, image_path)
-        new_image.add(iso_path, image_path, nil)
+        new_image.add(iso_path, image_path)
       end
 
       def add_xenserver(new_image, iso_path, image_path)
-        new_image.add(iso_path, image_path, nil)
+        new_image.add(iso_path, image_path)
+      end
+
+      def add_win(new_image, iso_path, image_path)
+        new_image.add(iso_path, image_path)
       end
 
       def add_os(new_image, iso_path, image_path, os_name, os_version)

--- a/core/slice/image.rb
+++ b/core/slice/image.rb
@@ -190,7 +190,15 @@ module ProjectHanlon
         json_data = body_hash.to_json
         puts "Attempting to add, please wait...".green
         result = hnl_http_post_json_data(uri, json_data)
-        print_object_array(hash_array_to_obj_array([result]), "Image Added:")
+        # if got a single hash map back, then print the details
+        return print_object_array(hash_array_to_obj_array([result]), "Image Added:") unless result.is_a?(Array)
+        # otherwise print the table containing the results
+        unless result.blank?
+          # convert it to a sorted array of objects (from an array of hashes)
+          sort_fieldname = 'wim_index'
+          result = hash_array_to_obj_array(expand_response_with_uris(result), sort_fieldname)
+        end
+        print_object_array(result, "Images:", :style => :table)
       end
 
       def remove_image

--- a/util/utility.rb
+++ b/util/utility.rb
@@ -70,6 +70,11 @@ module ProjectHanlon
       nil
     end
 
+    # searches for an executable (command) in the current path
+    def exec_in_path(command)
+      ENV['PATH'].split(':').collect {|d| Dir.entries d if Dir.exists? d}.flatten.include?(command)
+    end
+
     alias :new_object_from_type_name :new_object_from_template_name
 
 

--- a/web/api/api_image_v1.rb
+++ b/web/api/api_image_v1.rb
@@ -158,6 +158,7 @@ module Hanlon
             raise ProjectHanlon::Error::Slice::MissingArgument, '[/path/to/iso]' unless iso_path != nil && iso_path != ""
             classname = SLICE_REF.image_types[image_type.to_sym][:classname]
             image = ::Object::full_const_get(classname).new({})
+
             # We send the new image object to the appropriate method
             res = []
             unless image_type == "os"
@@ -168,6 +169,11 @@ module Hanlon
                                    ProjectHanlon.config.image_path, os_name, os_version
             end
             raise ProjectHanlon::Error::Slice::InternalError, res[1] unless res[0]
+            # TODO: Add code to support creation of multiple images that point to a common subdirectory
+            # that code should generate a new UUID for each sub-image and should reference a "hidden
+            # image" containing the reference to the underlying directory that the code was copied over
+            # into under it's own UUID; if it's not a "Windows" image should add a new image as is shown
+            # in the following line
             raise ProjectHanlon::Error::Slice::InternalError, "Could not save image." unless SLICE_REF.insert_image(image)
 
             # fix 125 - add image local path to image end point

--- a/web/api/api_image_v1.rb
+++ b/web/api/api_image_v1.rb
@@ -143,10 +143,6 @@ module Hanlon
             image_array
           end
 
-          def wiminfo_inpath
-            ENV['PATH'].split(':').collect {|d| Dir.entries d if Dir.exists? d}.flatten.include?('wiminfo')
-          end
-
           # get a list of all of the images that reference the image with a 'uuid'
           # corresponding to their 'base_image_uuid'
           def get_referencing_images(base_image_uuid)
@@ -231,7 +227,7 @@ module Hanlon
                                                                      SLICE_REF.image_types.keys.map { |k| k.to_s }.join(', ')
             end
             raise ProjectHanlon::Error::Slice::MissingArgument, '[/path/to/iso]' unless iso_path != nil && iso_path != ""
-            if image_type == 'win' && !wiminfo_inpath
+            if image_type == 'win' && !SLICE_REF.exec_in_path('wiminfo')
               raise ProjectHanlon::Error::Slice::InternalError, "Missing command 'wiminfo'; required to extract Windows images"
             end
 

--- a/web/api/api_image_v1.rb
+++ b/web/api/api_image_v1.rb
@@ -244,7 +244,7 @@ module Hanlon
                                    ProjectHanlon.config.image_path
             end
             raise ProjectHanlon::Error::Slice::InternalError, res[1] unless res[0]
-            raise ProjectHanlon::Error::Slice::InternalError, "Could not save base image." unless SLICE_REF.insert_image(image)
+            raise ProjectHanlon::Error::Slice::InternalError, "Could not save image." unless SLICE_REF.insert_image(image)
 
             # fix 125 - add image local path to image end point
             @_lcl_image_path = ProjectHanlon.config.image_path + "/"


### PR DESCRIPTION
The changes in this PR add the ability to add images contained in a Windows ISO to Hanlon using the `hanlon image add` command and remove the resulting images from Hanlon using the standard `hanlon image remove` command. In short, the changes are as follows:

* Adds support for creation of images from a Windows ISO using the `hanlon image add` command. First, the ISO file is 'unpacked', and a **hidden** image is created that references the extracted contents of that ISO. After that, the `wiminfo` command is used to extract a list of named **subimages** from the `install.wim` file extracted from that ISO, and a set of **linked** images are created that reference the hidden image that was created in the first step. Finally, the list of non-hidden images that were created by the `hanlon image add` command is returned to the user. The result is that adding a Windows ISO to Hanlon using the `hanlon image add` command will create multiple images, each named according to their description in the `install.wim` file contained in that ISO.
* Modifies the `hanlon image` command so that the default (get all) action only returns non-hidden images to the user
* Adds an additional flag to the `hanlon image` command (the 'hidden' flag) that can be used to return a list that contains all of the images currently managed by Hanlon (including the hidden ones).
* Modifies the output of the `hanlon image` command slightly to support the fact that we now have multiple images linked to the same ISO filename. The changes in this PR ensure that the name of the image is included in the output of this command if the image has a name associated with it; if not, then the ISO filename is included in that field instead.
* Modifies the code used to extract the contents of ISOs in the `ProjectHanlon::ImageService::Base` class so that the user can specify (in the extra argument to the `add` command) whether or not to validate that the complete list of files was copied over from the ISO to the image directory; this can save time when only one image is really important for validating that the ISO was successfully extracted (as is the case with Windows ISOs, where the only really important file is the `install.wim` file).
* Modifies the code used to extract the contents of ISOs in the `ProjectHanlon::ImageService::Base` class so that the user can specify which methods are supported for extracting a particular image; this is critical for some ISOs (the ESXi ISOs can be extracted using `fuseiso`, but `7zip` won't work with them, while Windows ISOs can be extracted using `7zip`, but any attempts to extract a Windows ISO using `fuseiso` will fail). Without this change, a common codebase for extracting all of the ISOs we support would simply not be possible.
* Modifies the code used to extract the contents of ISOs in the `ProjectHanlon::ImageService::Base` class so that extraction of ISOs using `7zip` is supported properly (this required disabling the validation that the copy from the ISO to the image was successful in those cases where `7zip` was used, since `7z` simply unpacks the ISO in place, so there is no source list to validate against).
* Modifies the `hanlon image remove` command so that it properly handles removal of the new **linked** images created when a Windows ISO is used to add images to Hanlon. In short, removal of the **base image** (the hidden image that was created by adding the ISO to Hanlon) will also result in removal of any images that that are linked to that base image, and removal of all of the images linked to a base image will result in removal of the base image as well.