### PR TITLE
Adds ability to serve up static content

### DIFF
--- a/core/config/server.rb
+++ b/core/config/server.rb
@@ -113,6 +113,8 @@ module ProjectHanlon
       attr_accessor :api_port
       attr_accessor :hanlon_log_level
 
+      attr_accessor :hanlon_static_path
+
       attr_accessor :mk_checkin_interval
       attr_accessor :mk_checkin_skew
 
@@ -194,7 +196,8 @@ module ProjectHanlon
           # used to set the Microkernel boot debug level; valid values are
           # either the empty string (the default), "debug", or "quiet"
           'hnl_mk_boot_debug_level'   => "Logger::ERROR",
-          'hanlon_log_level'   => "Logger::ERROR",
+          'hanlon_log_level'          => "Logger::ERROR",
+          'hanlon_static_path'        => "",
 
           # used to pass arguments to the Microkernel's linux kernel;
           # e.g. "console=ttyS0" or "hanlon.ip=1.2.3.4"


### PR DESCRIPTION
This PR adds a new `/static` endpoint to Hanlon that can be mapped to a directory in the Hanlon filesystem using a newly defined `hanlon_static_path` in the Hanlon server configuration file (which should be mapped to the directory containing the static content that should be served up by Hanlon). The code in this PR will catch errors where the file does not exist or is not a regular file and will return a 404 error in those cases.  An example of the use of this new functionality is the following curl command:
```bash
$ curl -g http://192.168.78.2:8026/hanlon/api/v1/static/COPYING
		    GNU GENERAL PUBLIC LICENSE
		       Version 2, June 1991

 Copyright (C) 1989, 1991 Free Software Foundation, Inc.
                       51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 Everyone is permitted to copy and distribute verbatim copies
 of this license document, but changing it is not allowed.

			    Preamble
.
.
.

$ 
```
which returns the COPYING file from a static content directory on my Hanlon server's local filesystem.