### PR TITLE
Slight refactoring to ensure calls to 'sources_fix' callback succeed

### DIFF
--- a/core/model/debian.rb
+++ b/core/model/debian.rb
@@ -118,11 +118,11 @@ module ProjectHanlon
           when "final"
             fsm_action(:os_final, :postinstall)
             return ""
-          when "source_fix"
-            fsm_action(:source_fix, :postinstall)
+          when "sources_fix"
+            fsm_action(:sources_fix, :postinstall)
             return
           when "send_ips"
-            #fsm_action(:source_fix, :postinstall)
+            #fsm_action(:sources_fix, :postinstall)
             # Grab IP string
             @ip_string = @args_array.shift
             logger.debug "Node IP String: #{@ip_string}"
@@ -162,7 +162,7 @@ module ProjectHanlon
             :mk_call            => :postinstall,
             :boot_call          => :postinstall,
             :preseed_end        => :postinstall,
-            :source_fix         => :postinstall,
+            :sources_fix         => :postinstall,
             :apt_get_update     => :postinstall,
             :apt_get_upgrade    => :postinstall,
             :postinstall_inject => :postinstall,

--- a/core/model/opensuse_12.rb
+++ b/core/model/opensuse_12.rb
@@ -108,11 +108,7 @@ module ProjectHanlon
           when "boot"
             fsm_action(:os_boot, :postinstall)
             return os_complete_script(@node)
-          when "source_fix"
-            fsm_action(:source_fix, :postinstall)
-            return
           when "send_ips"
-            #fsm_action(:source_fix, :postinstall)
             # Grab IP string
             @ip_string = @args_array.shift
             logger.debug "Node IP String: #{@ip_string}"
@@ -151,8 +147,7 @@ module ProjectHanlon
             :postinstall => {
                 :mk_call            => :postinstall,
                 :boot_call          => :postinstall,
-                :yast_end        => :postinstall,
-                :source_fix         => :postinstall,
+                :yast_end           => :postinstall,
                 :postinstall_inject => :postinstall,
                 :os_boot            => :os_complete,
                 :post_error         => :error_catch,

--- a/core/model/redhat.rb
+++ b/core/model/redhat.rb
@@ -119,7 +119,6 @@ module ProjectHanlon
             fsm_action(:os_final, :postinstall)
             return ""
           when "send_ips"
-            #fsm_action(:source_fix, :postinstall)
             # Grab IP string
             @ip_string = @args_array.shift
             logger.debug "Node IP String: #{@ip_string}"

--- a/core/model/sles_11.rb
+++ b/core/model/sles_11.rb
@@ -108,11 +108,7 @@ module ProjectHanlon
           when "boot"
             fsm_action(:os_boot, :postinstall)
             return os_complete_script(@node)
-          when "source_fix"
-            fsm_action(:source_fix, :postinstall)
-            return
           when "send_ips"
-            #fsm_action(:source_fix, :postinstall)
             # Grab IP string
             @ip_string = @args_array.shift
             logger.debug "Node IP String: #{@ip_string}"

--- a/core/model/ubuntu.rb
+++ b/core/model/ubuntu.rb
@@ -119,11 +119,10 @@ module ProjectHanlon
           when "final"
             fsm_action(:os_final, :postinstall)
             return ""
-          when "source_fix"
-            fsm_action(:source_fix, :postinstall)
+          when "sources_fix"
+            fsm_action(:sources_fix, :postinstall)
             return
           when "send_ips"
-            #fsm_action(:source_fix, :postinstall)
             # Grab IP string
             @ip_string = @args_array.shift
             logger.debug "Node IP String: #{@ip_string}"
@@ -163,7 +162,7 @@ module ProjectHanlon
             :mk_call            => :postinstall,
             :boot_call          => :postinstall,
             :preseed_end        => :postinstall,
-            :source_fix         => :postinstall,
+            :sources_fix         => :postinstall,
             :apt_get_update     => :postinstall,
             :apt_get_upgrade    => :postinstall,
             :postinstall_inject => :postinstall,


### PR DESCRIPTION
Previously calls to the `sources_fix` callback made during execution of the post-install boot process in the Debian and Ubuntu models would fail because the `sources_fix` callback actually incorrectly defined as the `source_fix` callback in the underlying models. This PR fixes that error (and removes this callback from the `redhat`, `sles11`, and `opensuse_12` models where it is never used).