### PR TITLE
Required PowerShell scripts to add Windows provisioning

### DIFF
--- a/scripts/winpe/build-winpe.ps1
+++ b/scripts/winpe/build-winpe.ps1
@@ -1,0 +1,182 @@
+﻿#!powershell
+
+###
+#
+# Utilized Code various code from multiple locations
+# Sources:
+# http://stackoverflow.com/questions/5648931/test-if-registry-value-exists
+# https://github.com/puppetlabs/razor-server/blob/master/build-winpe/build-razor-winpe.ps1
+### 
+
+
+###
+# Define Local Static Variables
+# winpeCabs - These are all the CABS that need to be installed to install Windows
+###
+
+
+$DebugPreference = "Continue"
+
+$PackageCabs = @( "WinPE-WMI.cab", "WinPE-NetFx.cab", 
+				"WinPE-Scripting.cab", "WinPE-PowerShell.cab", 
+				"WinPE-Setup.cab", "WinPE-Setup-Server.cab")
+
+$LangPackageCabs = @( "lp.cab", 
+                      "WinPE-Setup_en-us.cab", 
+                      "WinPE-Setup-Server_en-us.cab" )
+
+$SubPathWinPeImage = "Assessment and Deployment Kit\Windows Preinstallation Environment\amd64\en-us\winpe.wim"
+$SubPathPackages = "Assessment and Deployment Kit\Windows Preinstallation Environment\amd64\WinPE_OCs"
+$SubPathLangPackages = "Assessment and Deployment Kit\Windows Preinstallation Environment\amd64\WinPE_OCs\en-us"
+
+$MountPath = "$env:SystemDrive\mount-point"
+$WimPath = "$env:SystemDrive\winpe"
+$ScriptPath = "$env:SystemDrive\script"
+$DriversPath = "$env:SystemDrive\drivers"
+
+$paths = @($MountPath,$WimPath,$ScriptPath,$DriversPath)
+
+
+Function Test-RegistryValue {
+    param(
+        [Alias("PSPath")]
+        [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [String]$Path
+        ,
+        [Parameter(Position = 1, Mandatory = $true)]
+        [String]$Name
+        ,
+        [Switch]$PassThru
+    ) 
+
+    process {
+        if (Test-Path $Path) {
+            $Key = Get-Item -LiteralPath $Path
+            if ($Key.GetValue($Name, $null) -ne $null) {
+                if ($PassThru) {
+                    Get-ItemProperty $Path $Name
+                } else {
+                    $true
+                }
+            } else {
+                $false
+            }
+        } else {
+            $false
+        }
+    }
+}
+function test-administrator {
+    $identity  = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($Identity)
+    $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+function get-currentdirectory {
+    $thisName = $MyInvocation.MyCommand.Name
+    [IO.Path]::GetDirectoryName((Get-Content function:$thisName).File)
+}
+
+
+if (-not (test-administrator)) {
+    write-error @"
+You must be running as administrator for this script to function.
+Unfortunately, we can't reasonable elevate privileges ourselves
+so you need to launch an administrator mode command shell and then
+re-run this script yourself.
+"@
+    exit 1
+}
+
+
+# Lets create directories for WinPE build
+foreach ($p in $paths ) {
+    if (-not (test-path -path $p)) {
+        new-item -type directory $p
+    }
+}
+
+
+###
+# In order to create a WinPE image we need the ADK.  To automate the process of installing
+# the ADk we can use Chocolatey, lets install that now...
+###
+
+$result = Test-RegistryValue -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots\" -Name "KitsRoot81"
+
+if(-not $result) {
+
+    iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+
+###
+# Install Windows ADK only WinPE requirements
+###
+    choco install windows-adk-winpe -y
+}
+# OK where is the ADK?
+
+$KitsRoot81 = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots\" -Name "KitsRoot81").KitsRoot81
+
+$wim = Join-Path $KitsRoot81 $SubPathWinPeImage
+Write-Debug $wim
+
+Copy-Item $wim $WimPath
+
+mount-windowsimage -imagepath "$WimPath\winpe.wim" -index 1 -path $MountPath -erroraction stop
+
+
+foreach ($cab in $PackageCabs ) {
+    write-host "** Installing $cab to image"
+    # there must be a way to do this without a temporary variable
+    $path = "$KitsRoot81$SubPathPackages"
+
+    $pkg = join-path $path "$cab"
+    Write-Debug $pkg
+    add-windowspackage -packagepath $pkg -path $MountPath
+}
+
+foreach ($cab in $LangPackageCabs ) {
+    write-host "** Installing $cab to image"
+    # there must be a way to do this without a temporary variable
+    $path = "$KitsRoot81$SubPathLangPackages"
+
+    $pkg = join-path $path "$cab"
+    Write-Debug $pkg
+    add-windowspackage -packagepath $pkg -path $MountPath
+}
+
+
+Write-Host "** Installing Drivers to image"
+Add-WindowsDriver -Recurse -Path $MountPath -Driver $DriversPath
+
+write-host "* Writing startup PowerShell script"
+$file   = join-path $MountPath "hanlon-discover.ps1"
+$client = join-path $ScriptPath "hanlon-discover.ps1"
+copy-item $client $file
+ 
+write-host "* Writing Windows\System32\startnet.cmd script"
+$file = join-path $MountPath "Windows\System32\startnet.cmd"
+set-content $file @"
+@echo off
+echo Starting wpeinit...
+wpeinit
+echo Starting Hanlon discover and callbacks...
+powershell -executionpolicy bypass -file %SYSTEMDRIVE%\hanlon-discover.ps1
+echo dropping to a command shell now...
+"@
+
+write-host "* Removing setup.exe from image"
+$setup = join-path $MountPath "setup.exe"
+Write-Debug $setup
+Remove-Item $setup -ErrorAction SilentlyContinue
+
+Write-Host "* Generate Language Files"
+dism /image:$MountPath /gen-langini /distribution:$MountPath
+
+write-host "* Unmounting and saving the wim image"
+
+dismount-windowsimage -save -path $MountPath -erroraction stop
+
+Write-Host "* Moving winpe.wim to with date"
+$date = get-date -format M-d-yyyy-Hmm
+
+Move-Item "$WimPath\winpe.wim" "$WimPath\winpe-$date.wim"

--- a/scripts/winpe/build-winpe.ps1
+++ b/scripts/winpe/build-winpe.ps1
@@ -151,6 +151,9 @@ Add-WindowsDriver -Recurse -Path $MountPath -Driver $DriversPath
 write-host "* Writing startup PowerShell script"
 $file   = join-path $MountPath "hanlon-discover.ps1"
 $client = join-path $ScriptPath "hanlon-discover.ps1"
+
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/csc/Hanlon/master/scripts/winpe/hanlon-discover.ps1" -OutFile $client -UseBasicParsing
+
 copy-item $client $file
  
 write-host "* Writing Windows\System32\startnet.cmd script"
@@ -171,6 +174,17 @@ Remove-Item $setup -ErrorAction SilentlyContinue
 
 Write-Host "* Generate Language Files"
 dism /image:$MountPath /gen-langini /distribution:$MountPath
+
+
+Write-Host "* Loading WinPE System Registry"
+REG LOAD HKLM\TEMP C:\MOUNT-POINT\WINDOWS\SYSTEM32\CONFIG\SYSTEM
+
+Write-Host "* Set CDROM Start to DWORD 4"
+Set-ItemProperty -Path "HKLM:\TEMP\ControlSet001\Services\cdrom" -Name Start -Value 4
+
+Write-Host "* Unload WinPE System Registry"
+REG UNLOAD HKLM\TEMP
+
 
 write-host "* Unmounting and saving the wim image"
 

--- a/scripts/winpe/hanlon-discover.ps1
+++ b/scripts/winpe/hanlon-discover.ps1
@@ -1,0 +1,167 @@
+
+#http://www.ingmarverheij.com/read-dhcp-options-received-by-the-client/
+
+$HanlonDhcpOptionServer = 224;
+$HanlonDhcpOptionPort = 225;
+$HanlonDhcpOptionBaseuri = 226;
+$HanlonShareName = "Hanlon";
+
+$DebugPreference = "Continue";
+
+
+Function Get-HanlonDhcpOptionValue {
+	[CmdletBinding()]
+	param(
+		[Parameter(Position=0, Mandatory=$true)]
+		[System.Array]$DhcpInterfaceOptions,
+		[Parameter(Mandatory=$true)]
+		[System.Int16]$Location
+	)
+	begin {
+		$vendorLocation = $Location + 12;
+		$lengthLocation = $Location + 8;
+		$dataLocation = $Location + 20;
+		$result = @();
+	}
+	process {
+		try {
+			if( $DhcpInterfaceOptions[$vendorLocation] -eq 1 ) {
+				Write-Debug "Found Vendor Option";
+				if( ($length = $DhcpInterfaceOptions[$lengthLocation]) -gt 0 ) {
+					Write-Debug "Found Length: $length";
+					$start = $Location + 20;
+					$end = $dataLocation + $length;
+
+					for( $newpos = $dataLocation; $newpos -lt $end; $newpos++ ) {
+						$result += $DhcpInterfaceOptions[$newpos];
+					}
+				}
+				else {
+					throw "Length of Option Data is Zero, review DhcpInterfaceOptions";
+				}
+
+			} else {
+				throw "Vendor Location Is Not 1";
+			}
+		}
+		catch {
+			write-host "Exception $($_.Exception.GetType().FullName), Message: $($_.Exception.Message), Line Number: $($_.InvocationInfo.ScriptLineNumber), Offset Inline: $($_.InvocationInfo.OffsetInLine)" -ForegroundColor Red
+		}
+	}
+	end {return $result}
+}
+
+Function Get-HanlonServerParameters {
+	[CmdletBinding()]
+	param()
+	begin {
+		$HanlonObject = New-Object System.Object;
+	}
+	process {
+		try {
+			$networkAdapters = Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter "IPEnabled = 'True' AND DHCPEnabled ='True'";
+			foreach ( $na in $networkAdapters ) {
+				$interfaceRegPath = "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\Tcpip\Parameters\Interfaces\$($na.SettingID)\"
+				Write-Debug $interfaceRegPath;
+				$dhcpInterfaceOptions = (Get-ItemProperty -Path $interfaceRegPath -Name DhcpInterfaceOptions).DhcpInterfaceOptions
+
+				for( $pos = 0; $pos -lt $dhcpInterfaceOptions.Length; $pos++ ) {
+
+					switch ($dhcpInterfaceOptions[$pos]) {
+						$HanlonDhcpOptionServer {
+							Write-Debug "Found $HanlonDhcpOptionServer";
+							$result = Get-HanlonDhcpOptionValue -DhcpInterfaceOptions $dhcpInterfaceOptions -Location $pos
+							if( $result.Length -eq 4 ) {
+								$ipaddress = "{0}.{1}.{2}.{3}" -f $result[0], $result[1], $result[2], $result[3];
+								Write-Debug $ipaddress
+								$HanlonObject | Add-Member -Name IPAddress -Value $ipaddress -MemberType NoteProperty
+							}
+							else {
+								throw "Result Length Exception";
+							}
+
+						}
+						$HanlonDhcpOptionPort {
+							Write-Debug "Found $HanlonDhcpOptionPort";
+
+							$result = Get-HanlonDhcpOptionValue -DhcpInterfaceOptions $dhcpInterfaceOptions -Location $pos
+							if( $result.Length -eq 2 ) {
+								$port = (([int]$result[0]) -shl 8) + ([int]$result[1]);
+								Write-Debug $port
+								$HanlonObject | Add-Member -Name Port -Value $port -MemberType NoteProperty
+							}
+							else {
+								throw "Result Length Exception";
+							}
+
+						}
+						$HanlonDhcpOptionBaseuri {
+							Write-Debug "Found $HanlonDhcpOptionBaseuri";
+							$result = Get-HanlonDhcpOptionValue -DhcpInterfaceOptions $dhcpInterfaceOptions -Location $pos
+							$baseuri = "";
+							foreach ( $res in $result ) {
+								$baseuri += ([char]$res);
+							}
+							$HanlonObject | Add-Member -Name BaseUri -Value $baseuri -MemberType NoteProperty
+							Write-Debug "Base Uri: $baseuri";
+						}
+					}
+				}
+			}
+			#confirm members
+			if( ($HanlonObject | Get-Member -Name IPAddress) -eq $null ) {
+				throw "Missing Member IPAddress";
+			}
+			if( ($HanlonObject | Get-Member -Name BaseUri) -eq $null ) {
+				throw "Missing Member BaseUri";
+			}
+			if( ($HanlonObject | Get-Member -Name Port) -eq $null ) {
+				throw "Missing Member Port";
+			}
+		}
+		catch {
+			write-host "Exception $($_.Exception.GetType().FullName), Message: $($_.Exception.Message), Line Number: $($_.InvocationInfo.ScriptLineNumber), Offset Inline: $($_.InvocationInfo.OffsetInLine)" -ForegroundColor Red
+		}
+
+	}
+	end {
+		return $HanlonObject;
+	}
+}
+
+
+Function Invoke-Main {
+	[CmdletBinding()]
+	param()
+
+	begin {}
+	process {
+		try {
+			$HanlonServerSettings = Get-HanlonServerParameters 
+			$SmbiosUuid = (get-wmiobject win32_computersystemproduct).uuid
+
+			Write-Debug $SmbiosUuid
+
+            $hanlonBaseUri = "http://$($HanlonServerSettings.IPAddress):$($HanlonServerSettings.port)/$($HanlonServerSettings.baseuri)"
+
+            Write-Debug $hanlonBaseUri
+            $queryActiveModel = "$hanlonBaseUri/active_model?uuid=$SmbiosUuid"
+
+            Write-Debug $queryActiveModel
+            $activeModel = Invoke-WebRequest -Uri $queryActiveModel -UseBasicParsing | ConvertFrom-Json
+
+            $activeModelUuid = Invoke-WebRequest -Uri $activeModel.response."@uri" -UseBasicParsing | ConvertFrom-Json
+            $uuid = $activeModelUuid.response."@uuid"
+
+            iex ((new-object net.webclient).DownloadString("$hanlonBaseUri/policy/callback/$uuid/install/file")) 
+
+	}
+		catch {
+			write-host "Exception $($_.Exception.GetType().FullName), Message: $($_.Exception.Message), Line Number: $($_.InvocationInfo.ScriptLineNumber), Offset Inline: $($_.InvocationInfo.OffsetInLine)" -ForegroundColor Red
+		}
+	}
+	end {}
+
+}
+
+Invoke-Main

--- a/scripts/winpe/hanlon-discover.ps1
+++ b/scripts/winpe/hanlon-discover.ps1
@@ -23,7 +23,7 @@ $octets = $rawUUID.Split("-")
 # Create an array of each two-charactere byte (space delimiter)
 $bytes = $octets[0].Split(" ") + $octets[1].Split(" ")
 # Build the final string, piecing together byte by byte
-$prettyUUID = $bytes[3] + $bytes[2] + $bytes[1] + $bytes[0] + "-" + $bytes[5] + $bytes[4] + "-" + $bytes[7] + $bytes[6] + "-" + $bytes[8] + $bytes[9] + "-" + $bytes[10] + $bytes[11] + $bytes[12] + $bytes[13] + $bytes[14] + $bytes[15]
+$prettyUUID = $bytes[0] + $bytes[1] + $bytes[2] + $bytes[3] + "-" + $bytes[4] + $bytes[5] + "-" + $bytes[6] + $bytes[7] + "-" + $bytes[8] + $bytes[9] + "-" + $bytes[10] + $bytes[11] + $bytes[12] + $bytes[13] + $bytes[14] + $bytes[15]
 Return $prettyUUID
 
 }
@@ -162,11 +162,17 @@ Function Invoke-Main {
 
             $result = [regex]::match($IdentifyingNumber,'VMware\-(.*)').Groups[1]
 
+            Write-Debug $result
+
             if( $result.Success ) {
+                Write-Debug "Begin If"
                 $SmbiosUuid = Convert-SmbiosUuid -rawUUID $result.Value
+                Write-Debug "End If"
             }
             else {
+                Write-Debug "Begin Else"
                 $SmbiosUuid = (get-wmiobject win32_computersystemproduct).uuid
+                Write-Debug "End Else"
 
             }
 


### PR DESCRIPTION
The build-winpe.ps1 creates the required WinPE to provision a Windows 2012
R2 server.  The hanlon-discover.ps1 retrieves from the registry the
vendor specific options and determines the SMBIOS uuid to grab the hanlon
image uuid and active_model/policy uuid.

Resolves issue #323 