### PR TITLE
CoreOS Model

### DIFF
--- a/core/config/server.rb
+++ b/core/config/server.rb
@@ -222,6 +222,8 @@ module ProjectHanlon
           next if interface_name == 'lo'
           ip_addr = Facter::Util::IP.get_interface_value(interface_name,'ipaddress')
           netmask = Facter::Util::IP.get_interface_value(interface_name,'netmask')
+          # skip to next if interface does not have an ip address assinged
+          next if ip_addr == ""
           subnet_str = IPAddr.new("#{ip_addr}/#{netmask}").to_s
           subnet_str_array << "#{subnet_str}/#{netmask_to_cidr(netmask)}"
         }

--- a/core/model/coreos.rb
+++ b/core/model/coreos.rb
@@ -1,0 +1,274 @@
+require "erb"
+
+# Root ProjectHanlon namespace
+module ProjectHanlon
+  module ModelTemplate
+    # Root Model object
+    # @abstract
+    class Coreos < ProjectHanlon::ModelTemplate::Base
+      include(ProjectHanlon::Logging)
+
+      # Assigned image
+      attr_accessor :image_uuid
+      # Metadata
+      attr_accessor :hostname
+      attr_accessor :domainname
+      # Compatible Image Prefix
+      attr_accessor :image_prefix
+
+      def initialize(hash)
+        super(hash)
+        # Static config
+        @hidden      = true
+        @template = :linux_deploy
+        @name = "coreos generic"
+        @description = "CoreOS Generic Model"
+        # Metadata vars
+        @hostname_prefix = nil
+        # State / must have a starting state
+        @current_state = :init
+        # Image UUID
+        @image_uuid = true
+        # Image prefix we can attach
+        @image_prefix = "os"
+        # Enable agent brokers for this model
+        @broker_plugin = :agent
+        @final_state = :os_complete
+        from_hash(hash) unless hash == nil
+        @req_metadata_hash = {
+          "@hostname_prefix" => {
+            :default     => "node",
+            :example     => "node",
+            :validation  => '^[a-zA-Z0-9][a-zA-Z0-9\-]*$',
+            :required    => true,
+            :description => "node hostname prefix (will append node number)"
+          },
+          "@domainname" => {
+            :default     => "localdomain",
+            :example     => "example.com",
+            :validation  => '^[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9](\.[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])*$',
+            :required    => true,
+            :description => "local domain name (will be used in /etc/hosts file)",
+          "@install_disk" => { 
+            :default      => "/dev/sda",
+            :example      => "/dev/sda",
+            :validation   => '',
+            :required     => false,
+            :description  => "The Core OS target disk" },
+          }
+        }
+        @opt_metadata_hash = {
+          "@cloud_config" => { 
+            :default      => "",
+            :example      => "",
+            :validation   => '',
+            :required     => false,
+            :description  => "A yaml containing CoreOS cloud config options" },
+          }
+      end
+
+      def callback
+        {
+          "postinstall" => :postinstall_call,
+          "cloud-config.sh" => :cloud_config_call,
+        }
+      end
+
+      def broker_agent_handoff
+        logger.debug "Broker agent called for: #{@broker.name}"
+        if @node_ip
+          options = {
+            :username  => "root",
+            :password  => @root_password,
+            :metadata  => node_metadata,
+            :uuid  => @node.uuid,
+            :ipaddress => @node_ip,
+          }
+          @current_state = @broker.agent_hand_off(options)
+        else
+          logger.error "Node IP address isn't known"
+          @current_state = :broker_fail
+        end
+        broker_fsm_log
+      end
+      
+      def cloud_config_call
+        return generate_cloud_config(@policy_uuid)
+      end
+
+      def postinstall_call
+        @arg = @args_array.shift
+        case @arg
+          when "send_ips"
+            # Grab IP string
+            @ip_string = @args_array.shift
+            logger.debug "Node IP String: #{@ip_string}"
+            @node_ip = @ip_string if @ip_string =~ /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/
+            return
+          when "complete"
+            fsm_action(:install_complete, :os_complete)
+            return
+          when "install_fail"
+            fsm_action(:post_error, :os_complete)
+            return
+          else
+            fsm_action(@arg.to_sym, :postinstall)
+            return
+        end
+      end
+
+      # Defines our FSM for this model
+      #  For state => {action => state, ..}
+      def fsm_tree
+        {
+          :init => {
+            :mk_call       => :init,
+            :boot_call     => :init,
+            :timeout       => :timeout_error,
+            :error         => :error_catch,
+            :else          => :init,
+            :install_complete => :os_complete 
+          },
+          :postinstall => {
+            :mk_call            => :postinstall,
+            :boot_call          => :postinstall,
+            :os_boot            => :postinstall,
+            :os_final           => :os_complete,
+            :post_error         => :error_catch,
+            :post_timeout       => :timeout_error,
+            :error              => :error_catch,
+            :else               => :postinstall
+          },
+          :os_complete => {
+            :mk_call   => :os_complete,
+            :boot_call => :os_complete,
+            :else      => :os_complete,
+            :reset     => :init
+          },
+          :timeout_error => {
+            :mk_call   => :timeout_error,
+            :boot_call => :timeout_error,
+            :else      => :timeout_error,
+            :reset     => :init
+          },
+          :error_catch => {
+            :mk_call   => :error_catch,
+            :boot_call => :error_catch,
+            :else      => :error_catch,
+            :reset     => :init
+          },
+        }
+      end
+
+      def mk_call(node, policy_uuid)
+        super(node, policy_uuid)
+        case @current_state
+          # We need to reboot
+          when :init, :preinstall, :postinstall, :os_validate, :os_complete, :broker_check, :broker_fail, :broker_success
+            ret = [:reboot, {}]
+          when :timeout_error, :error_catch
+            ret = [:acknowledge, {}]
+          else
+            ret = [:acknowledge, {}]
+        end
+        fsm_action(:mk_call, :mk_call)
+        ret
+      end
+
+      def boot_call(node, policy_uuid)
+        super(node, policy_uuid)
+        case @current_state
+          when :init, :preinstall
+            @result = "Starting CoreOS model install"
+            ret = start_install(node, policy_uuid)
+          when :postinstall, :os_complete, :broker_check, :broker_fail, :broker_success, :complete_no_broker
+            ret = local_boot(node)
+          when :timeout_error, :error_catch
+            engine = ProjectHanlon::Engine.instance
+            ret = engine.default_mk_boot(node.uuid)
+          else
+            engine = ProjectHanlon::Engine.instance
+            ret = engine.default_mk_boot(node.uuid)
+        end
+        fsm_action(:boot_call, :boot_call)
+        ret
+      end
+
+      # ERB.result(binding) is failing in Ruby 1.9.2 and 1.9.3 so template is processed in the def block.
+      def template_filepath(filename)
+        filepath = File.join(File.dirname(__FILE__), "coreos/#{filename}.erb")
+      end
+
+      def os_boot_script(policy_uuid)
+        @result = "Replied with os boot script"
+        filepath = template_filepath('os_boot')
+        ERB.new(File.read(filepath)).result(binding)
+      end
+
+      def os_complete_script(node)
+        @result = "Replied with os complete script"
+        filepath = template_filepath('os_complete')
+        ERB.new(File.read(filepath)).result(binding)
+      end
+
+      def start_install(node, policy_uuid)
+        filepath = template_filepath('boot_install')
+        ERB.new(File.read(filepath)).result(binding)
+      end
+
+      def local_boot(node)
+        filepath = template_filepath('boot_local')
+        ERB.new(File.read(filepath)).result(binding)
+      end
+
+      def kernel_args(policy_uuid)
+        filepath = template_filepath('kernel_args')
+        ERB.new(File.read(filepath)).result(binding)
+      end
+
+      def hostname
+        "#{@hostname_prefix}#{@counter.to_s}"
+      end
+      
+      def install_disk
+        @install_disk
+      end
+
+      def cloud_config_yaml
+        @cloud_config.to_yaml
+      end
+
+      def kernel_path
+        "coreos/vmlinuz"
+      end
+
+      def initrd_path
+        "coreos/cpio.gz"
+      end
+      
+      # TODO: make optional
+      # This will only affect the boot for install. It is helpful to debug errors
+      def autologin_kernel_args
+        "console=tty0 console=ttyS0 coreos.autologin=tty1 coreos.autologin=ttyS0"
+      end
+
+      def config
+        ProjectHanlon.config
+      end
+
+      def image_svc_uri
+        "http://#{config.hanlon_server}:#{config.api_port}#{config.websvc_root}/image/os"
+      end
+
+      def api_svc_uri
+        "http://#{config.hanlon_server}:#{config.api_port}#{config.websvc_root}"
+      end
+      
+      def generate_cloud_config(policy_uuid)
+        filepath = template_filepath('cloud-config')
+        ERB.new(File.read(filepath)).result(binding)
+      end
+
+    end
+  end
+end

--- a/core/model/coreos.rb
+++ b/core/model/coreos.rb
@@ -48,13 +48,14 @@ module ProjectHanlon
             :example     => "example.com",
             :validation  => '^[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9](\.[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])*$',
             :required    => true,
-            :description => "local domain name (will be used in /etc/hosts file)",
+            :description => "local domain name (will be used in /etc/hosts file)"
+          },
           "@install_disk" => { 
             :default      => "/dev/sda",
             :example      => "/dev/sda",
             :validation   => '',
             :required     => false,
-            :description  => "The Core OS target disk" },
+            :description  => "The Core OS target disk"
           }
         }
         @opt_metadata_hash = {
@@ -63,8 +64,9 @@ module ProjectHanlon
             :example      => "",
             :validation   => '',
             :required     => false,
-            :description  => "A yaml containing CoreOS cloud config options" },
+            :description  => "A yaml containing CoreOS cloud config options"
           }
+        }
       end
 
       def callback

--- a/core/model/coreos.rb
+++ b/core/model/coreos.rb
@@ -33,6 +33,10 @@ module ProjectHanlon
         @image_prefix = "os"
         # Enable agent brokers for this model
         @broker_plugin = :agent
+        # Default install disk
+        @install_disk = "/dev/sda"
+        # Default: no cloud config
+        @cloud_config = nil
         @final_state = :os_complete
         from_hash(hash) unless hash == nil
         @req_metadata_hash = {
@@ -49,16 +53,16 @@ module ProjectHanlon
             :validation  => '^[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9](\.[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])*$',
             :required    => true,
             :description => "local domain name (will be used in /etc/hosts file)"
-          },
+          }
+        }
+        @opt_metadata_hash = {
           "@install_disk" => { 
             :default      => "/dev/sda",
             :example      => "/dev/sda",
             :validation   => '',
             :required     => false,
             :description  => "The Core OS target disk"
-          }
-        }
-        @opt_metadata_hash = {
+          },
           "@cloud_config" => { 
             :default      => "",
             :example      => "",
@@ -237,7 +241,11 @@ module ProjectHanlon
       end
 
       def cloud_config_yaml
-        @cloud_config.to_yaml
+        if @cloud_config
+          @cloud_config.to_yaml
+        else
+          ""
+        end
       end
 
       def kernel_path
@@ -256,14 +264,6 @@ module ProjectHanlon
 
       def config
         ProjectHanlon.config
-      end
-
-      def image_svc_uri
-        "http://#{config.hanlon_server}:#{config.api_port}#{config.websvc_root}/image/os"
-      end
-
-      def api_svc_uri
-        "http://#{config.hanlon_server}:#{config.api_port}#{config.websvc_root}"
       end
       
       def generate_cloud_config(policy_uuid)

--- a/core/model/coreos/boot_install.erb
+++ b/core/model/coreos/boot_install.erb
@@ -1,0 +1,10 @@
+#!ipxe
+echo Hanlon <%= @label %> model boot_call
+echo Installation node UUID : <%= node.uuid %>
+echo Installation image UUID: <%= @image_uuid %>
+echo Active Model node state: <%= @current_state %>
+
+sleep 3
+kernel <%= "#{image_svc_uri}/#{@image_uuid}/#{kernel_path} #{kernel_args(policy_uuid)}" %> || goto error
+initrd <%= "#{image_svc_uri}/#{@image_uuid}/#{initrd_path}" %> || goto error
+boot

--- a/core/model/coreos/boot_local.erb
+++ b/core/model/coreos/boot_local.erb
@@ -1,0 +1,9 @@
+#!ipxe
+echo Hanlon <%= @label %> model boot_call
+echo Installation node UUID : <%= node.uuid %>
+echo Installation image UUID: <%= @image_uuid %>
+echo Active Model node state: <%= @current_state %>
+echo Continuing local boot
+
+sleep 3
+sanboot --no-describe --drive 0x80

--- a/core/model/coreos/cloud-config.erb
+++ b/core/model/coreos/cloud-config.erb
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# See CoreOS cloud config for supported options:
+# https://coreos.com/docs/cluster-management/setup/cloudinit-cloud-config/
+cat > /tmp/cloud-config.yaml <<EOF
+#cloud-config
+<%= cloud_config_yaml %>
+hostname: <%= hostname %>
+EOF
+
+sudo coreos-install -d <%= install_disk %> -c /tmp/cloud-config.yaml
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "complete") %> || curl <%= callback_url("postinstall", "install_fail") %>
+
+sudo reboot
+

--- a/core/model/coreos/kernel_args.erb
+++ b/core/model/coreos/kernel_args.erb
@@ -1,0 +1,1 @@
+<%= autologin_kernel_args %> cloud-config-url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/cloud-config.sh" %>

--- a/core/model/coreos_stable.rb
+++ b/core/model/coreos_stable.rb
@@ -1,0 +1,19 @@
+module ProjectHanlon
+  module ModelTemplate
+
+    class CoreosStable < Coreos
+      include(ProjectHanlon::Logging)
+
+      def initialize(hash)
+        super(hash)
+        # Static config
+        @hidden      = false
+        @name        = "coreos_stable"
+        @description = "coreos stable"
+        @osversion   = "557"
+
+        from_hash(hash) unless hash == nil
+      end
+    end
+  end
+end

--- a/core/model/model_dep.rb
+++ b/core/model/model_dep.rb
@@ -18,6 +18,7 @@ require 'model/sles_11'
 require 'model/vmware_esxi'
 require 'model/xenserver'
 require 'model/windows'
+require 'model/coreos'
 
 # level 3 - redhat
 require 'model/redhat_6'
@@ -46,3 +47,6 @@ require 'model/xenserver_tampa'
 
 # level 3 - windows
 require 'model/windows_2012_r2'
+
+# level 3 - coreos
+require 'model/coreos_stable'


### PR DESCRIPTION
To install a CoreOS node, set up hanlon with the following commands (tested in VirtualBox, hence the tag. YMMV):

```
hanlon image add -t mk -p /vagrant/isos/hnl_mk_dev-image.2.0.1.iso
hanlon image add -t os -p /vagrant/isos/coreos_557.iso -v 557
IMAGE_UUID=$(hanlon image | grep coreos | awk '{print $1}')
hanlon model add --template coreos_stable --label install_coreos --image-uuid $IMAGE_UUID -o /vagrant/hanlon-config/model.yaml
MODEL_UUID=$(hanlon model | grep coreos | awk '{print $5}')
hanlon policy add --template linux_deploy --label coreos --model-uuid $MODEL_UUID  --broker-uuid=none --tags OracleCorporation -e true
```

For `model.yaml` use this:

```
hostname_prefix: "coreosnode"
domainname: localdomain
cloud_config:
  coreos:
    units:
      - name: etcd.service
        command: start
      - name: fleet.service
        command: start
  ssh_authorized_keys:
    - ssh-rsa AAAAB3NzaC1y....yourkey
install_disk: '/dev/sda'
```

The cloudconfig part is based on [CoreOS Cloud Config](https://coreos.com/docs/cluster-management/setup/cloudinit-cloud-config/)