### PR TITLE
Fixing version number in DockerFile and hanlon.gemspec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Hanlon server
 #
-# VERSION 2.0.0
+# VERSION 2.2.0
 
 FROM ubuntu:latest
 MAINTAINER Joseph Callen <jcpowermac@gmail.com>

--- a/hanlon.gemspec
+++ b/hanlon.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'hanlon'
-  s.version     = '2.0.0'
-  s.date        = '2014-10-30'
+  s.version     = '2.2.0'
+  s.date        = '2012-03-05'
   s.summary     = 'Project Hanlon'
   s.description = 'Next-generation automation software for bare-metal and virtual server provisioning'
   s.authors     = ['Nicholas Weaver', 'Tom McSweeney']

--- a/hanlon.gemspec
+++ b/hanlon.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'hanlon'
   s.version     = '2.2.0'
-  s.date        = '2012-03-05'
+  s.date        = '2015-03-05'
   s.summary     = 'Project Hanlon'
   s.description = 'Next-generation automation software for bare-metal and virtual server provisioning'
   s.authors     = ['Nicholas Weaver', 'Tom McSweeney']


### PR DESCRIPTION
These two files each contain a Hanlon version that should have been updated prior to yesterday's release; this PR updates these two files to reflect the new version number.