### PR TITLE
.gitignore Update for Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,5 @@ doc/
 /image
 /node_modules
 /hanlon_daemon.pid
-/Gemfile.lock
 
 /ext/packaging

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,132 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    CFPropertyList (2.2.8)
+    activesupport (4.2.0)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    atomic (1.1.99)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
+    base62 (1.0.0)
+    bson (1.9.2)
+    builder (3.2.2)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
+    colored (1.2)
+    daemons (1.1.9)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
+    diff-lcs (1.2.5)
+    equalizer (0.0.9)
+    facter (2.4.1)
+      CFPropertyList (~> 2.2.6)
+    grape (0.9.0)
+      activesupport
+      builder
+      hashie (>= 2.1.0)
+      multi_json (>= 1.3.2)
+      multi_xml (>= 0.5.2)
+      rack (>= 1.3.0)
+      rack-accept
+      rack-mount
+      virtus (>= 1.0.0)
+    grape-entity (0.4.4)
+      activesupport
+      multi_json (>= 1.3.2)
+    grape-swagger (0.8.0)
+      grape
+      grape-entity
+    hashie (3.4.0)
+    i18n (0.7.0)
+    ice_nine (0.11.1)
+    jdbc-postgres (9.4.1200)
+    jruby-jars (1.7.19)
+    jruby-rack (1.1.18)
+    json (1.8.2)
+    logger (1.2.8)
+    macaddr (1.7.1)
+      systemu (~> 2.6.2)
+    minitest (5.5.1)
+    mongo (1.9.2)
+      bson (~> 1.9.2)
+    multi_json (1.11.0)
+    multi_xml (0.5.5)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
+    puma (2.11.1)
+      rack (>= 1.1, < 2.0)
+    rack (1.6.0)
+    rack-accept (0.4.5)
+      rack (>= 0.4)
+    rack-mount (0.8.3)
+      rack (>= 1.0.0)
+    rake (10.4.2)
+    require_all (1.3.2)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.1)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
+    rubyipmi (0.8.1)
+    rubyzip (1.1.7)
+    rufus-scheduler (3.0.9)
+      tzinfo
+    systemu (2.6.4)
+    thread_safe (0.3.4)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    uuid (2.3.7)
+      macaddr (~> 1.0)
+    virtus (1.0.4)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
+    warbler (1.4.5)
+      jruby-jars (>= 1.5.6, < 2.0)
+      jruby-rack (>= 1.1.1, < 1.3)
+      rake (>= 0.9.6)
+      rubyzip (>= 0.9, < 1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  atomic
+  base62
+  bson (~> 1.9.2)
+  colored
+  daemons
+  facter
+  grape (~> 0.9.0)
+  grape-swagger (~> 0.8.0)
+  jdbc-postgres
+  json (>= 1.7.7)
+  logger
+  mongo
+  net-scp
+  net-ssh
+  puma
+  require_all
+  rspec (>= 2.13.0)
+  rspec-expectations (>= 2.13.0)
+  rspec-mocks (>= 2.13.0)
+  rubyipmi
+  rufus-scheduler
+  uuid
+  warbler


### PR DESCRIPTION
Gemfile.lock should be in version control. This will keep gem versions consistent between development and production deployment.

http://bundler.io/v1.8/rationale.html#checking-your-code-into-version-control

Fixes #331