### PR TITLE
Resolves #340 (Add ability to specify **logical or** of tags for policies)

### DIFF
--- a/core/policy/base.rb
+++ b/core/policy/base.rb
@@ -24,6 +24,9 @@ module ProjectHanlon
       attr_accessor :line_number
       attr_accessor :bind_counter
 
+      # used to determine how to match policies to nodes
+      attr_accessor :match_using
+
 
       # TODO - method for setting tags that removes duplicates
 
@@ -40,6 +43,7 @@ module ProjectHanlon
         @node_uuid = nil
         @bind_timestamp = nil
         @bound = false
+        @match_using = 'and'
         @noun = "policy"
 
         from_hash(hash) unless hash == nil
@@ -108,6 +112,10 @@ module ProjectHanlon
 
       end
 
+      def get_tag_string
+        @tags.join((@match_using == 'and' ? "," : '|'))
+      end
+
       def print_header
         if @bound
           return "Label", "State", "Node UUID", "Broker", "Bind #", "UUID"
@@ -129,7 +137,7 @@ module ProjectHanlon
             return @template.to_s, @description.to_s
           else
             max_num = @maximum_count.to_i == 0 ? '-' : @maximum_count
-            return @line_number.to_s, @enabled.to_s, @label, "[#{@tags.join(",")}]", @model.label.to_s, "#{@bind_counter}/#{max_num}", @model.counter.to_s, @uuid
+            return @line_number.to_s, @enabled.to_s, @label, "[#{get_tag_string}]", @model.label.to_s, "#{@bind_counter}/#{max_num}", @model.counter.to_s, @uuid
           end
         end
       end
@@ -154,6 +162,7 @@ module ProjectHanlon
            "Template",
            "Description",
            "Tags",
+           "Match Using",
            "Model Label",
            "Broker Target",
            "Currently Bound",
@@ -184,7 +193,8 @@ module ProjectHanlon
            @enabled.to_s,
            @template.to_s,
            @description,
-           "[#{@tags.join(", ")}]",
+           "[#{get_tag_string}]",
+           @match_using,
            @model.label.to_s,
            broker_name,
            #current_count.to_s,

--- a/core/slice/policy.rb
+++ b/core/slice/policy.rb
@@ -324,5 +324,3 @@ module ProjectHanlon
     end
   end
 end
-
-


### PR DESCRIPTION
The changes in this PR add code to Hanlon that allows for the use of either a `,` or an `|` character as a separator in the tag strings used to specify the tags for a policy when when creating/updating policies. The rules are relatively simple:

* if a `,` character is used, an 'and' comparison of the tags in a node with the tags in a policy will be used to see if a given policy matches a given node (i.e. all of the policy tags must match tags assigned to the node or there is no match between the node and the policy)
* if an `|` character is used, an 'or' comparison of the tags in a node with the tags in a policy will be used to see if a given policy matches a given node (i.e. at least one of the policy tags must match with a tag assigned to the node or there is no match between the node and the policy)
* if both `,` and `|` separators are detected in the tag string, then an error is thrown (i.e. you can define a policy that will use an `and` comparison and a policy that will use an `or` comparison, but we don't support mixed use of both `and` and `or` in the same policy)

When combined with the changes just merged as part of PR #339, this PR should allow for creation of a single policy that will match multiple nodes (by constructing a policy using an `|` separated tag string containing the set of node-specific tags for the nodes the policy should apply to).