### PR TITLE
Adds an "in-memory" CoreOS model to Hanlon

### DIFF
--- a/core/model/coreos.rb
+++ b/core/model/coreos.rb
@@ -21,7 +21,7 @@ module ProjectHanlon
         # Static config
         @hidden      = true
         @template = :linux_deploy
-        @name = "coreos generic"
+        @name = "coreos_generic"
         @description = "CoreOS Generic Model"
         # Metadata vars
         @hostname_prefix = nil

--- a/core/model/coreos/cloud-config.erb
+++ b/core/model/coreos/cloud-config.erb
@@ -2,7 +2,7 @@
 
 # See CoreOS cloud config for supported options:
 # https://coreos.com/docs/cluster-management/setup/cloudinit-cloud-config/
-cat > /tmp/cloud-config.yaml <<EOF
+cat > /tmp/cloud-config.yaml << EOF
 #cloud-config
 <%= cloud_config_yaml %>
 hostname: <%= hostname %>

--- a/core/model/coreos/cloud_config_in_memory.erb
+++ b/core/model/coreos/cloud_config_in_memory.erb
@@ -1,0 +1,3 @@
+#cloud-config
+<%= cloud_config_yaml %>
+hostname: <%= hostname %>

--- a/core/model/coreos/kernel_args_in_memory.erb
+++ b/core/model/coreos/kernel_args_in_memory.erb
@@ -1,0 +1,1 @@
+sshkey="<%= "#{ssh_key}" %>" <%= autologin_kernel_args %>

--- a/core/model/coreos/kernel_args_in_memory.erb
+++ b/core/model/coreos/kernel_args_in_memory.erb
@@ -1,1 +1,1 @@
-sshkey="<%= "#{ssh_key}" %>" <%= autologin_kernel_args %>
+<%= autologin_kernel_args %> cloud-config-url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/cloud-config" %>

--- a/core/model/coreos_in_memory.rb
+++ b/core/model/coreos_in_memory.rb
@@ -13,8 +13,6 @@ module ProjectHanlon
         @hidden      = false
         @name        = "coreos_in_memory"
         @description = "CoreOS In-Memory"
-        # initialize SSH key to nil
-        # @ssh_key     = nil
         # Default: no cloud config
         @cloud_config = nil
 
@@ -48,14 +46,9 @@ module ProjectHanlon
 
       def callback
         {
-            # "ssh-key" => :ssh_key,
             "cloud-config" => :cloud_config_call,
         }
       end
-
-      # def ssh_key
-      #   return @ssh_key
-      # end
 
       def cloud_config_call
         return generate_cloud_config(@policy_uuid)
@@ -118,7 +111,6 @@ module ProjectHanlon
       # TODO: make optional
       # This will only affect the boot for install. It is helpful to debug errors
       def autologin_kernel_args
-        # "coreos pxe demo"
         "console=tty0 console=ttyS0"
       end
 

--- a/core/model/coreos_in_memory.rb
+++ b/core/model/coreos_in_memory.rb
@@ -1,0 +1,114 @@
+module ProjectHanlon
+  module ModelTemplate
+
+    class CoreosInMemory < InMemory
+      include(ProjectHanlon::Logging)
+
+      # setup an accessor for the ssh_key instance var
+      attr_accessor :ssh_key
+
+      def initialize(hash)
+        super(hash)
+        # Static config
+        @hidden      = false
+        @name        = "coreos_in_memory"
+        @description = "CoreOS In-Memory"
+        # initialize SSH key to nil
+        @ssh_key     = nil
+
+        @req_metadata_hash = {
+          "@hostname_prefix" => {
+            :default     => "node",
+            :example     => "node",
+            :validation  => '^[a-zA-Z0-9][a-zA-Z0-9\-]*$',
+            :required    => true,
+            :description => "node hostname prefix (will append node number)"
+          },
+          "@domainname" => {
+            :default     => "localdomain",
+            :example     => "example.com",
+            :validation  => '^[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9](\.[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])*$',
+            :required    => true,
+            :description => "local domain name (will be used in /etc/hosts file)"
+          },
+          "@ssh_key" => {
+            :default      => "",
+            :example      => "",
+            :validation   => '',
+            :required     => true,
+            :description  => "the (public) SSH key to use when connecting to the CoreOS instance"
+          }
+        }
+        from_hash(hash) unless hash == nil
+      end
+
+      def callback
+        {
+            "ssh-key" => :ssh_key,
+        }
+      end
+
+      def ssh_key
+        return @ssh_key
+      end
+
+      def boot_call(node, policy_uuid)
+        super(node, policy_uuid)
+        case @current_state
+          when :init, :preinstall
+            @result = "Starting CoreOS In-Memory model boot"
+            ret = start_install(node, policy_uuid)
+          when :timeout_error, :error_catch
+            engine = ProjectHanlon::Engine.instance
+            ret = engine.default_mk_boot(node.uuid)
+          else
+            engine = ProjectHanlon::Engine.instance
+            ret = engine.default_mk_boot(node.uuid)
+        end
+        fsm_action(:boot_call, :boot_call)
+        ret
+      end
+
+
+      # will perform an "install" of CoreOS by booting
+      # into an in-memory image
+      def start_install(node, policy_uuid)
+        filepath = template_filepath('boot_install')
+        ERB.new(File.read(filepath)).result(binding)
+      end
+
+      # ERB.result(binding) is failing in Ruby 1.9.2 and 1.9.3 so template is processed in the def block.
+      def template_filepath(filename)
+        filepath = File.join(File.dirname(__FILE__), "coreos/#{filename}.erb")
+      end
+
+      def kernel_args(policy_uuid)
+        filepath = template_filepath('kernel_args_in_memory')
+        ERB.new(File.read(filepath)).result(binding)
+      end
+
+      def hostname
+        "#{@hostname_prefix}#{@counter.to_s}"
+      end
+
+      def kernel_path
+        "coreos/vmlinuz"
+      end
+
+      def initrd_path
+        "coreos/cpio.gz"
+      end
+
+      # TODO: make optional
+      # This will only affect the boot for install. It is helpful to debug errors
+      def autologin_kernel_args
+        "coreos pxe demo"
+      end
+
+      def config
+        ProjectHanlon.config
+      end
+
+    end
+  end
+end

--- a/core/model/coreos_stable.rb
+++ b/core/model/coreos_stable.rb
@@ -9,8 +9,7 @@ module ProjectHanlon
         # Static config
         @hidden      = false
         @name        = "coreos_stable"
-        @description = "coreos stable"
-        @osversion   = "557"
+        @description = "CoreOS Stable"
 
         from_hash(hash) unless hash == nil
       end

--- a/core/model/in_memory.rb
+++ b/core/model/in_memory.rb
@@ -1,0 +1,91 @@
+require "erb"
+
+# Root ProjectHanlon namespace
+module ProjectHanlon
+  module ModelTemplate
+    # Root Model object
+    # @abstract
+    class InMemory < ProjectHanlon::ModelTemplate::Base
+      include(ProjectHanlon::Logging)
+
+      # Assigned image
+      attr_accessor :image_uuid
+      # Metadata
+      attr_accessor :hostname
+      attr_accessor :domainname
+      # Compatible Image Prefix
+      attr_accessor :image_prefix
+
+      def initialize(hash)
+        super(hash)
+        # Static config
+        @hidden      = true
+        @template = :linux_deploy
+        @name = "in_memory"
+        @description = "Generic In-Memory Model"
+        # Metadata vars
+        @hostname_prefix = nil
+        # State / must have a starting state
+        @current_state = :init
+        # Image UUID
+        @image_uuid = true
+        # Image prefix we can attach
+        @image_prefix = "os"
+        # Enable agent brokers for this model
+        @broker_plugin = :agent
+        @final_state = :os_complete
+        from_hash(hash) unless hash == nil
+      end
+
+      # Defines our FSM for this model
+      #  For state => {action => state, ..}
+      def fsm_tree
+        {
+          :init => {
+            :mk_call       => :init,
+            :boot_call     => :init,
+            :timeout       => :timeout_error,
+            :error         => :error_catch,
+            :else          => :init,
+          },
+          :timeout_error => {
+            :mk_call   => :timeout_error,
+            :boot_call => :timeout_error,
+            :else      => :timeout_error,
+            :reset     => :init
+          },
+          :error_catch => {
+            :mk_call   => :error_catch,
+            :boot_call => :error_catch,
+            :else      => :error_catch,
+            :reset     => :init
+          },
+        }
+      end
+
+      def mk_call(node, policy_uuid)
+        super(node, policy_uuid)
+        case @current_state
+          # We need to reboot
+          when :init, :preinstall
+            ret = [:reboot, {}]
+          when :timeout_error, :error_catch
+            ret = [:acknowledge, {}]
+          else
+            ret = [:acknowledge, {}]
+        end
+        fsm_action(:mk_call, :mk_call)
+        ret
+      end
+
+      def hostname
+        "#{@hostname_prefix}#{@counter.to_s}"
+      end
+
+      def config
+        ProjectHanlon.config
+      end
+
+    end
+  end
+end

--- a/core/model/model_dep.rb
+++ b/core/model/model_dep.rb
@@ -19,6 +19,7 @@ require 'model/vmware_esxi'
 require 'model/xenserver'
 require 'model/windows'
 require 'model/coreos'
+require 'model/in_memory'
 
 # level 3 - redhat
 require 'model/redhat_6'
@@ -50,3 +51,4 @@ require 'model/windows_2012_r2'
 
 # level 3 - coreos
 require 'model/coreos_stable'
+require 'model/coreos_in_memory'


### PR DESCRIPTION
This PR adds a new `CoreosInMemory` model to Hanlon (which extends a new `InMemory` model type, which itself extends the `Base` model type). We've also added a new pair of methods to the `Utility` module used across Hanlon that can be used to convert a BSON::OrderedHash (the data type returned from MongoDB to Hanlon) to a regular Ruby Hash. This method is needed to create a 'clean' YAML for use as the `cloud-config` that is passed into the CoreOS instance that a node boots into when bound to the new `CoreosInMemory` model. Without this method, the cloud-config passed through to the CoreOS instance looks like this:
```yaml
#cloud-config
--- !ruby/hash:BSON::OrderedHash
coreos: !ruby/hash:BSON::OrderedHash
  units:
  - !ruby/hash:BSON::OrderedHash
    name: etcd.service
    command: start
  - !ruby/hash:BSON::OrderedHash
    name: fleet.service
    command: start
ssh_authorized_keys:
- ssh-rsa AAAAB3N...[your RSA public key goes here]
hostname: coreosnode1
```
but with this code, the YAML generated is something that CoreOS can actually parse (without Ruby):
```yaml
#cloud-config
---
coreos:
  units:
  - name: etcd.service
    command: start
  - name: fleet.service
    command: start
ssh_authorized_keys:
- ssh-rsa AAAAB3N...[your RSA public key goes here]
hostname: coreosnode1
```