### PR TITLE
enabling bson by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'base62'
 gem 'colored'
 gem 'bson'
 # bson_ext is disabled to facilitate support of running Hanlon under jRuby.
-# gem 'bson_ext'
+gem 'bson_ext'
 gem 'json'
 gem 'net-ssh'
 gem 'net-scp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,8 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     base62 (1.0.0)
     bson (1.12.0)
+    bson_ext (1.12.0)
+      bson (~> 1.12.0)
     builder (3.2.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -107,6 +109,7 @@ PLATFORMS
 DEPENDENCIES
   base62
   bson
+  bson_ext
   colored
   daemons
   facter


### PR DESCRIPTION
between the errors and speed improvement and unknown percentage of user trying to deploy hanlon as a war, I suggest enabling bson by default to ease adoption