### PR TITLE
Fixes #363 (coreos_in_memory stays in init state, even when it's up with no broker)

### DIFF
--- a/core/model/coreos.rb
+++ b/core/model/coreos.rb
@@ -75,8 +75,8 @@ module ProjectHanlon
 
       def callback
         {
-          "postinstall" => :postinstall_call,
-          "cloud-config.sh" => :cloud_config_call,
+          "postinstall"  => :postinstall_call,
+          "cloud-config" => :cloud_config_call,
         }
       end
 

--- a/core/model/coreos.rb
+++ b/core/model/coreos.rb
@@ -242,7 +242,7 @@ module ProjectHanlon
 
       def cloud_config_yaml
         if @cloud_config
-          @cloud_config.to_yaml
+          bson_ordered_hash_to_hash(@cloud_config).to_yaml.strip
         else
           ""
         end

--- a/core/model/coreos/kernel_args.erb
+++ b/core/model/coreos/kernel_args.erb
@@ -1,1 +1,1 @@
-<%= autologin_kernel_args %> cloud-config-url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/cloud-config.sh" %>
+<%= autologin_kernel_args %> cloud-config-url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/cloud-config" %>

--- a/core/model/coreos/kernel_args_in_memory.erb
+++ b/core/model/coreos/kernel_args_in_memory.erb
@@ -1,1 +1,0 @@
-<%= autologin_kernel_args %> cloud-config-url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/cloud-config" %>

--- a/core/model/in_memory.rb
+++ b/core/model/in_memory.rb
@@ -41,25 +41,42 @@ module ProjectHanlon
       #  For state => {action => state, ..}
       def fsm_tree
         {
-          :init => {
-            :mk_call       => :init,
-            :boot_call     => :init,
-            :timeout       => :timeout_error,
-            :error         => :error_catch,
-            :else          => :init,
-          },
-          :timeout_error => {
-            :mk_call   => :timeout_error,
-            :boot_call => :timeout_error,
-            :else      => :timeout_error,
-            :reset     => :init
-          },
-          :error_catch => {
-            :mk_call   => :error_catch,
-            :boot_call => :error_catch,
-            :else      => :error_catch,
-            :reset     => :init
-          },
+            :init => {
+                :mk_call          => :init,
+                :boot_call        => :init,
+                :timeout          => :timeout_error,
+                :error            => :error_catch,
+                :else             => :init,
+                :install_complete => :os_complete
+            },
+            :postinstall => {
+                :mk_call            => :postinstall,
+                :boot_call          => :postinstall,
+                :os_boot            => :postinstall,
+                :os_final           => :os_complete,
+                :post_error         => :error_catch,
+                :post_timeout       => :timeout_error,
+                :error              => :error_catch,
+                :else               => :postinstall
+            },
+            :os_complete => {
+                :mk_call   => :os_complete,
+                :boot_call => :os_complete,
+                :else      => :os_complete,
+                :reset     => :init
+            },
+            :timeout_error => {
+                :mk_call   => :timeout_error,
+                :boot_call => :timeout_error,
+                :else      => :timeout_error,
+                :reset     => :init
+            },
+            :error_catch => {
+                :mk_call   => :error_catch,
+                :boot_call => :error_catch,
+                :else      => :error_catch,
+                :reset     => :init
+            },
         }
       end
 
@@ -67,7 +84,7 @@ module ProjectHanlon
         super(node, policy_uuid)
         case @current_state
           # We need to reboot
-          when :init, :preinstall
+          when :init, :postinstall, :os_complete, :broker_check, :broker_fail, :broker_success
             ret = [:reboot, {}]
           when :timeout_error, :error_catch
             ret = [:acknowledge, {}]


### PR DESCRIPTION
The changes in this PR modify the "CoreOS In-memory" model so that once node finishes booting into an in-memory CoreOS instance for the first time it is transitioned to a "complete" state.

This PR also includes a small fix to the "CoreOS" model that is extended by the "CoreOS Standard" model that was similar to the fix we made to the "CoreOS In-memory" model to ensure we don't try to pass the YAML version of a BSON OrderedHash to the underlying CoreOS instance as it's cloud-config (making it unusable by the CoreOS instance) and a couple of small changes to that same model so that we can minimize the amount of code duplication in our ERB templates for these two related models (the standard and in-memory CoreOS models).

With these changes in place, the CoreOS in memory model now transitions successfully to the `:complete` state once the OS finishes booting up (and remains in that state when the node is rebooted into another in-memory CoreOS instance later). Here are the logs for a node that was bound to a CoreOS in-memory model, booted up into that OS successfully, and then was rebooted twice:
```bash
$ hanlon active_model -i 564DF1A7-1B78-F6B1-55F9-774F8C95CD68 logs

             State                    Action                      Result                   Time     Last    Total           Node
init                             mk_call           n/a                                   09:17:34  0 sec   0 sec    mxes1vHbiQwEEPxvbZ7BY
init                             boot_call         Starting CoreOS In-Memory model boot  09:17:54  20 sec  20 sec   mxes1vHbiQwEEPxvbZ7BY
init=>os_complete                install_complete  n/a                                   09:18:10  16 sec  36 sec   mxes1vHbiQwEEPxvbZ7BY
os_complete=>complete_no_broker  broker_check      No broker attached                    09:18:10  0 sec   36 sec   mxes1vHbiQwEEPxvbZ7BY
complete_no_broker               boot_call         Starting CoreOS In-Memory model boot  09:18:43  33 sec  1.1 min  mxes1vHbiQwEEPxvbZ7BY
complete_no_broker               boot_call         Starting CoreOS In-Memory model boot  09:19:27  44 sec  1.9 min  mxes1vHbiQwEEPxvbZ7BY
$ 
```
Without the changes in this PR, this instance would have remained in the `:init` state and never would have transitioned into the `os_complete/complete_no_broker` states.