### PR TITLE
Fixes #362 (If ifconfig unavailable hanlon_init fails)

### DIFF
--- a/core/config/server.rb
+++ b/core/config/server.rb
@@ -62,7 +62,13 @@ module Facter::Util::IP
     if interface_info_cmd
       case label
         when 'netmask'
+puts "interface_info_cmd => '#{interface_info_cmd}'"
+puts "interface_info_cmd => '#{interface}'"
+test = %x{#{interface_info_cmd} route show dev #{interface}}
+puts "ip route output:\n#{test}"
           cidr_str = %x{#{interface_info_cmd} route show dev #{interface} | grep -v '^default' | awk '{print $1}'}.strip
+puts "cidr_str => '#{cidr_str}'"
+puts "regex match => #{/^[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\/([\d]{1,2})$/.match(cidr_str).inspect}"
           cidr = /^[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\/([\d]{1,2})$/.match(cidr_str)[1].to_i
           output = cidr_to_netmask(cidr)
         when 'ipaddress'


### PR DESCRIPTION
The changes in this pull request add the commands to the Facter::Util::IP module that we've customized for use in the `ProjectHanlon::Config::Server` class. With these changes, this class now supports the use of the `ip` command instead of the `ifconfig` command on systems where the `ifconfig` command is not available. In fact, we now use the `ip` command by default, and only attempt to use the `ifconfig` command if the `ip` command is not available. This should resolve the issue referenced above.