### PR TITLE
Preparing to tag for a v2.3.0 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Hanlon server
 #
-# VERSION 2.2.0
+# VERSION 2.3.0
 
 FROM ruby:2.2-wheezy
 MAINTAINER Joseph Callen <jcpowermac@gmail.com>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/csc/Hanlon.svg?branch=master)](https://travis-ci.org/csc/Hanlon)
 
-# Project Hanlon (v2.2.0)
+# Project Hanlon (v2.3.0)
 
 [![Join the chat at https://gitter.im/csc/Hanlon](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/csc/Hanlon?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/hanlon.gemspec
+++ b/hanlon.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'hanlon'
-  s.version     = '2.2.0'
+  s.version     = '2.3.0'
   s.date        = '2015-03-05'
   s.summary     = 'Project Hanlon'
   s.description = 'Next-generation automation software for bare-metal and virtual server provisioning'


### PR DESCRIPTION
Recent changes to the Dockerfile require a new tag to ensure that the new Dockerfile is used in the dockerhub build...