### PR TITLE
Adding ability to rebind a node to an in-memory model (temporarily)

### DIFF
--- a/core/node.rb
+++ b/core/node.rb
@@ -60,6 +60,8 @@ class ProjectHanlon::Node < ProjectHanlon::Object
     time_diff = Time.now.to_i - @timestamp.to_i
     status = "-"
     case @status
+      when "rebind"
+        status = "R"
       when "bound"
         status = "B"
       when "inactive"

--- a/core/rebind_request.rb
+++ b/core/rebind_request.rb
@@ -1,0 +1,45 @@
+# Root ProjectHanlon::Node namespace
+class ProjectHanlon::RebindRequest < ProjectHanlon::Object
+  attr_accessor :node_uuid
+  attr_accessor :timestamp
+
+  # init
+  # @param hash [Hash]
+  def initialize(hash)
+    super()
+    @_namespace = :rebind_request
+    @noun = "rebind_request"
+    @node_uuid = ""
+    @timestamp = Time.now.to_i
+    from_hash(hash)
+  end
+
+  def uuid=(new_uuid)
+    @uuid = new_uuid.upcase
+  end
+
+  def print_header
+    return "UUID", "Node UUID", "Request Time"
+  end
+
+  def print_items
+    return @uuid, @node_uuid, Time.at(@timestamp.to_i).strftime("%m-%d-%y %H:%M:%S")
+  end
+
+  def print_item_header
+    return "UUID", "Node UUID", "Request Time"
+  end
+
+  def print_item
+    return @uuid, @node_uuid, Time.at(@timestamp.to_i).strftime("%m-%d-%y %H:%M:%S"), @node_uuid
+  end
+
+  def line_color
+    :white_on_black
+  end
+
+  def header_color
+    :red_on_black
+  end
+
+end

--- a/core/slice.rb
+++ b/core/slice.rb
@@ -315,8 +315,8 @@ class ProjectHanlon::Slice < ProjectHanlon::Object
 
   # used by the slices to print out detailed usage for individual commands
   def print_command_help(command, option_items, optparse_options = { })
-    unless optparse_options[:banner]
-      banner = ( option_items.select { |elem| elem[:uuid_is] == "required" }.length > 0 ?
+    unless optparse_options[:banner] && !optparse_options[:banner].empty?
+      optparse_options[:banner] = ( option_items.select { |elem| elem[:uuid_is] == "required" }.length > 0 ?
           "hanlon #{slice_name} #{command} (UUID) (options...)" :
           "hanlon #{slice_name} #{command} (options...)")
     end


### PR DESCRIPTION
This PR adds a new "rebind" action to the node slice.  When you "set" a rebinding request, Hanlon will boot the node into the appropriate in-memory model on the next reboot, then boot back into the bound active_model after that.

An in-memory model is considered to be "appropriate" if the node would bind to it based on the tags assigned to that node and the tags for that in-memory model. The rules for that "rebinding" are the same as those that would be followed in binding the node to any other model via the policy table, except that only in-memory models are considered during this rebinding process.

Once the node has been "rebound" to an existing in-memory model, the rebinding request for that node will be removed from the system. If no in-memory model exists that the node can bind to, then the rebinding request will remain active until an appropriate model is found on a subsequent reboot or the rebinding request is cancelled.

Attempts to add a second rebinding request for a given node will fail with an error return.  Attempts to cancel a rebinding request for a node when no rebinding request exists for that node will also fail with an error. In the current implementation, we do not support rebinding to an in-memory model for more than one reboot (although the current model could probably be extended to support that sort of construct if necessary).