### PR TITLE
Fixes #40 (Access to partial image paths should return a proper error)

### DIFF
--- a/web/api/api_image_v1.rb
+++ b/web/api/api_image_v1.rb
@@ -275,7 +275,7 @@ module Hanlon
               # only allow access to this resource from the Hanlon subnet
               unless request_is_from_hanlon_subnet(env['REMOTE_ADDR'])
                 env['api.format'] = :text
-                raise ProjectHanlon::Error::Slice::MethodNotAllowed, "Remote Access Forbidden; access to /image/{component} resource is not allowed from outside of the Hanlon subnet"
+                raise ProjectHanlon::Error::Slice::MethodNotAllowed, "Remote Access Forbidden; access to /image/#{component} resource is not allowed from outside of the Hanlon subnet"
               end
             end
             params do
@@ -315,7 +315,7 @@ module Hanlon
 
                 rescue Exception => e
                   puts "An exception occuring serving image path #{filepath}"
-                  logger.log_exception e
+                  raise ProjectHanlon::Error::Slice::InputError, "Cannot find resource /image/#{component}"
                 end
 
               end


### PR DESCRIPTION
The changes in this PR return a proper error in these situations rather than returning the rather generic (and incorrect error) that was returned previously. Specifically, prior to the changes in this PR, attempts to access a partial path to an image resource or to access a non-existent resource under an image path would result in an error that looked something like this being thrown:
```json
{
  "response": {
    "result": {
      "code": 500,
      "type": "NameError",
      "description": "undefined local variable or method `logger' for #<Grape::Endpoint:0x00000002d98210>"
    }
  }
}
```
This error was the result of an attempt to use the non-existent `logger` object when reporting the actual error that occured, an object that is undefined in the context of the Grape endpoint in question (the image endpoint). With the changes in this pull request, an error that looks like this is reported instead:
```json
{
  "response": {
    "result": {
      "code": 500,
      "type": "ProjectHanlon::Error::Slice::InputError",
      "description": "Cannot find resource /image/os/6qeVWuZp7WWAq9rSWwC7MG"
    }
  }
}
```
Obviously, this error is much more informative, and lets the user know what actually happened (rather than just showing that there is an error in the codebase itself). The example shown above is the output shown when a user attempts to access a partial path to a resource under a given image path, but the same sort of error will be thrown if the user attempts to access a non-existent resource under that same image path. In both cases, the correct error type (a `ProjectHanlon::Error::Slice::InputError`) with a much clearer message (explaining exactly what resource couldn't be accessed) is returned to the user.