### PR TITLE
Fixes #358 (Inform that an mk is needed rather than return undefined method `uuid' for nil)

### DIFF
--- a/core/engine.rb
+++ b/core/engine.rb
@@ -45,6 +45,7 @@ module ProjectHanlon
 
         mk_image
       else
+        logger.error "Microkernel image does not exist"
         nil
       end
     end
@@ -297,7 +298,9 @@ module ProjectHanlon
     def default_mk_boot(uuid)
       logger.info "Responding with MK Boot - Node: #{uuid}"
       default = ProjectHanlon::PolicyTemplate::BootMK.new({})
-      default.get_boot_script(default_mk)
+      default_mk_ref = default_mk
+      return default.get_error_script("Microkernel image not found") unless default_mk_ref
+      default.get_boot_script(default_mk_ref)
     end
 
     ########

--- a/core/policy/boot_mk.rb
+++ b/core/policy/boot_mk.rb
@@ -38,9 +38,17 @@ module ProjectHanlon
         boot_script << "initrd #{image_svc_uri}/#{default_mk.initrd} || goto error\n"
         boot_script << "boot || goto error\n"
         boot_script << "\n\n\n"
-        boot_script << ":error\necho ERROR, will reboot in #{@config.mk_checkin_interval}\nsleep #{@config.mk_checkin_interval}\nreboot\n"
+        boot_script << ":error\necho ERROR, will reboot in #{@config.mk_checkin_interval} seconds\nsleep #{@config.mk_checkin_interval}\nreboot\n"
         boot_script
       end
+
+      def get_error_script(error_message)
+        error_script = ""
+        error_script << "#!ipxe\n"
+        error_script << "echo #{error_message}, will reboot in #{@config.mk_checkin_interval} seconds\nsleep #{@config.mk_checkin_interval}\nreboot\n"
+        error_script
+      end
+
     end
   end
 end


### PR DESCRIPTION
Prior to the changes in this PR, users who attempted to boot an unknown node against Hanlon would receive a fairly hard to interpret "parse error" in the console as the node iPXE-booted against Hanlon if they had forgotten to add a Microkernel image to Hanlon before doing so. This was because the output of such a request was a JSON response containing a rather cryptic error rather than a proper iPXE-boot script:
```json
{
  "response": {
    "result": {
      "code": 500,
      "type": "NoMethodError",
      "description": "undefined method `uuid' for nil:NilClass"
    }
  }
}
```
The changes in this PR add an error-handling PXE-boot script to Hanlon that will echo out the fact that a Microkernel could not be found, then sleep the node for 30 seconds, and then reboot it. This error-handling script will be returned whenever a Microkernel instance has not yet been added to Hanlon and an unknown node is attempting to iPXE-boot against it. An example of the output (as is seen by the user in the console of their node) is shown below:
![missing-mk-error](https://cloud.githubusercontent.com/assets/1375734/7119972/9e512a0a-e1be-11e4-81e7-10d69c963805.png)
The changes in this PR should be more than sufficient to resolve the issue referenced above. Users are now informed that a Microkernel instance could not be found in the system, providing them with the information they need to resolve the issue.