### PR TITLE
Fixes #32 (Attempting to construct model with MK throws an exception)

### DIFF
--- a/core/slice/model.rb
+++ b/core/slice/model.rb
@@ -310,14 +310,14 @@ module ProjectHanlon
         puts result
       end
 
-      def verify_image(model, image_uuid)
+      def get_image(image_uuid)
         uri = URI.parse ProjectHanlon.config.hanlon_uri + ProjectHanlon.config.websvc_root + "/image/#{image_uuid}"
         # and get the results of the appropriate RESTful request using that URI
         result = hnl_http_get(uri)
-        # finally, based on the options selected, print the results
+        # finally, return the result (as an image object)
         image = hash_to_obj(result)
         if image && (image.class != Array || image.length > 0)
-          return image if model.image_prefix == image.path_prefix
+          return image
         end
         nil
       end


### PR DESCRIPTION
The issue referenced above is actually somewhat misleading.  The problem is actually that without the changes in this PR Hanlon tells the user that the image used when attempting to create an OS model using a MK image cannot be found, as can be seen in this output:
```bash
[root@ubuntu-server Hanlon (master ✗)]$ hanlon model add -t redhat_6 -l "test model" -o rhel6-model.yaml -i 1cW7cFPodqlUAnAHPkBqeO
--- Building Model (redhat_6):

[model] [add_model] <-Invalid Image UUID [1cW7cFPodqlUAnAHPkBqeO]

Command help:
hanlon model add (options...)
    -t, --template MODEL_TEMPLATE            The model template to use for the new model.
    -l, --label MODEL_LABEL                  The label to use for the new model.
    -i, --image-uuid IMAGE_UUID              The image UUID to use for the new model.
    -o, --option YAML_FILE                   Use optional yaml file to create model
    -h, --help                               Display this screen.
[root@ubuntu-server Hanlon (master ✗)]$ 
```
The changes in this PR resolve this issue by separating out the loading of the image itself from the check of image type that is made during the model creation/update process. Previously, a call was made to the model slice's `verify_image` method to compare the image passed in by the user with the image type expected for the model being created/updated, but there were two errors that resulted in the same `nil` return value from this method (either that the image referenced by UUID did not exist or that the image existed but was not the correct type). The changes in this pull request remove this ambiguity and ensure that the correct error is thrown in both of these edge cases (as can be seen from the output shown, below):

![catching-mk-model-errors](https://cloud.githubusercontent.com/assets/1375734/7123589/0e7e17a2-e1d8-11e4-9782-02d103d7c515.png)

With these changes in place, the issue referenced above is resolved completely.