### PR TITLE
Resolves #352 (Given a policy, retrieve it's active_model and nodes)

### DIFF
--- a/core/slice.rb
+++ b/core/slice.rb
@@ -298,6 +298,7 @@ class ProjectHanlon::Slice < ProjectHanlon::Object
     optparse = get_options(options, optparse_options)
     # set the command help text to the string output from optparse
     @command_help_text << optparse.to_s
+    @command_help_text << "\t#{optparse_options[:note]}" if optparse_options[:note]
     # parse our ARGV with the optparse unless options are already set from get_options_web
     optparse.parse!(@command_array) unless option_items.any? { |k| options[k] }
     # validate required options, we use the :require_one logic to check if at least one :required value is present
@@ -322,6 +323,7 @@ class ProjectHanlon::Slice < ProjectHanlon::Object
     end
     optparse_options[:options_items] = option_items
     usage_lines = get_options({}, optparse_options).to_s.split("\n")
+    usage_lines << "\t#{optparse_options[:note]}" if optparse_options[:note]
     if usage_lines
       puts "Usage: #{usage_lines[0]}"
       usage_lines[1..usage_lines.size].each { |line|
@@ -534,6 +536,12 @@ class ProjectHanlon::Slice < ProjectHanlon::Object
     end
 
     object_hash
+  end
+
+  def add_field_to_query_string(uri_string, fieldname, value)
+    # if there's already a query string in this uri_string, then
+    # just append to it, otherwise start a new query string
+    /^[a-z]+:\/\/[^\?]+\?\S+$/.match(uri_string) ? uri_string << "&#{fieldname}=#{value}" : uri_string << "?#{fieldname}=#{value}"
   end
 
   def print_single_item(obj)

--- a/core/slice/active_model.rb
+++ b/core/slice/active_model.rb
@@ -92,10 +92,11 @@ module ProjectHanlon
         puts "Active Model Slice: used to view active models or active model logs (and to remove active models).".red
         puts "Active Model Commands:".yellow
         puts "\thanlon active_model [get] [all]                            " + "View all active models".yellow
+        puts "\thanlon active_model [get] [all] --policy,-o POLICY_UUID    " + "View all active models bound by a policy".yellow
+        puts "\thanlon active_model logs                                   " + "Prints an aggregate view of active model logs".yellow
         puts "\thanlon active_model [get] (UUID) [logs]                    " + "View specific active model (log)".yellow
         puts "\thanlon active_model [get] --node_uuid,-n NODE_UUID [logs]  " + "View (log for) active_model bound to node".yellow
         puts "\thanlon active_model [get] --hw_id,-i HW_ID [logs]          " + "View (log for) active_model bound to node".yellow
-        puts "\thanlon active_model logs                                   " + "Prints an aggregate view of active model logs".yellow
         puts "\thanlon active_model remove (UUID)                          " + "Remove specific active model".yellow
         puts "\thanlon active_model remove --node_uuid,-n NODE_UUID        " + "Remove active_model bound to node".yellow
         puts "\thanlon active_model remove --hw_id,-i HW_ID                " + "Remove active_model bound to node".yellow
@@ -109,7 +110,7 @@ module ProjectHanlon
                   :default     => nil,
                   :short_form  => '-o',
                   :long_form   => '--policy POLICY_UUID',
-                  :description => 'Show only nodes bound by this policy instance',
+                  :description => 'Show only active_models bound by this policy instance',
                   :uuid_is     => 'not_allowed',
                   :required    => false
                 }

--- a/core/slice/active_model.rb
+++ b/core/slice/active_model.rb
@@ -26,35 +26,31 @@ module ProjectHanlon
             nil,
             "remove_all_active_models",
             "remove_active_model_by_uuid")
-
         # and add a few more commands specific to this slice; first remove the default line that
         # handles the lines where a UUID is passed in as part of a "get_active_model_by_uuid" command
-        tmp_map = commands[:get][/^(?!^(all|\-\-help|\-h|\{\}|\{.*\}|nil)$)\S+$/]
-        commands[:get].delete(/^(?!^(all|\-\-help|\-h|\{\}|\{.*\}|nil)$)\S+$/)
+        tmp_map = commands[:get].delete(/^(?!^(all|\-\-help|\-h|\{\}|\{.*\}|nil)$)\S+$/)
         # then add a slightly different version of this line back in; one that incorporates
-        # the other four flags we might pass in as part of a "get_all_active_models" command
-        commands[:get][/^(?!^(all|\-\-hw_id|\-i|\-\-node_uuid|\-n|\-\-help|\-h|\{\}|\{.*\}|nil)$)\S+$/] = tmp_map
-        # and add in a couple of lines that handle those four flags properly
-        [["-i", "--hw_id"], ["-n", "--node_uuid"]].each { |val|
-          commands[:get][val] = "get_all_active_models"
+        # the other flags we might pass in as part of a "get_all_nodes" or "get_node_by_uuid" command
+        commands[:get][/^(?!^(all|\-\-hw_id|\-i|\-\-policy|\-o|\-\-node_uuid|\-n|\-\-help|\-h|\{\}|\{.*\}|nil)$)\S+$/] = tmp_map
+        # add in a couple of lines to that handle those flags properly
+        commands[:get][["-o", "--policy"]] = "get_all_active_models"
+        [["-i", "--hw_id"],["-n", "--node_uuid"]].each { |val|
+          commands[:get][val] = "get_active_model_by_uuid"
         }
-
         # next, remove the default line that handles the commands where the user is wanting to
         # remove an active_model instance by (active_model) uuid
-        tmp_map = commands[:remove][/^(?!^(all|\-\-help|\-h)$)\S+$/]
-        commands[:remove].delete(/^(?!^(all|\-\-help|\-h)$)\S+$/)
+        tmp_map = commands[:remove].delete(/^(?!^(all|\-\-help|\-h)$)\S+$/)
         # then add a slightly different version of this line back in; one that incorporates
-        # the other four flags we might pass in as part of a "remove_active_model_by_uuid" command
-        commands[:remove][/^(?!^(all|\-\-hw_id|\-i|\-\-node_uuid|\-n|\-\-help|\-h)$)\S+$/] = tmp_map
-        # and add in a couple of lines that handle those four flags properly
+        # the other flags we might pass in as part of a "remove_active_model_by_uuid" command
+        commands[:remove][/^(?!^(all|\-\-hw_id|\-i|\-\-policy|\-o|\-\-node_uuid|\-n|\-\-help|\-h|\{\}|\{.*\}|nil)$)\S+$/] = tmp_map
+        # and add in a couple of lines that handle these flags properly
         [["-i", "--hw_id"], ["-n", "--node_uuid"]].each { |val|
           commands[:remove][val] = "remove_active_model_by_uuid"
         }
-
         # finally, add in a couple of lines to properly handle "get_active_model_logs" commands
         commands[:logs] = "get_logs"
         commands[:logs][/^(?!^(\-\-hw_id|\-i|\-\-node_uuid|\-n|\{\}|\{.*\}|nil)$)\S+$/] = "get_active_model_logs"
-        commands[:get][/^(?!^(all|\-\-hw_id|\-i|\-\-node_uuid|\-n|\-\-help|\-h|\{\}|\{.*\}|nil)$)\S+$/][:logs] = "get_active_model_logs"
+        commands[:get][/^(?!^(all|\-\-hw_id|\-i|\-\-policy|\-o|\-\-node_uuid|\-n|\-\-help|\-h|\{\}|\{.*\}|nil)$)\S+$/][:logs] = "get_active_model_logs"
 
         commands
       end
@@ -65,12 +61,24 @@ module ProjectHanlon
           begin
             # load the option items for this command (if they exist) and print them
             option_items = command_option_data(command)
-            print_command_help(command, option_items)
+            # need to handle the usage for the 'get' and and "remove" commands a bit differently;
+            # the active_model can be identified it's UUID or by either the UUID or the Hardware ID
+            # of the node bound to it, but only one (so the UUID is optional, but required if neither
+            # the UUID nor the Hardware ID of the bound node are included)
+            optparse_options = { }
+            optparse_options[:banner] = "hanlon active_model_help #{command} [UUID] (options...)" if ['get', 'remove'].include?(command)
+            optparse_options[:note] = "Note; one (and only one) of the active_model UUID, the HW_ID of the bound node,\n\t  or the UUID of the bound node must be provided" if ['get', 'remove'].include?(command)
+            print_command_help(command, option_items, optparse_options)
             return
           rescue
-            # ignored
           end
         end
+        # if here, then either there are no specific options for the current command or we've
+        # been asked for generic help, so provide generic help
+        puts get_active_model_help
+      end
+
+      def get_active_model_help
         # if here, then either there are no specific options for the current command or we've
         # been asked for generic help, so provide generic help
         puts "Active Model Slice: used to view active models or active model logs (and to remove active models).".red
@@ -86,43 +94,86 @@ module ProjectHanlon
         puts "\thanlon active_model --help|-h                              " + "Display this screen".yellow
       end
 
+      def all_command_option_data
+        {
+            :get_all => [
+                { :name        => :policy,
+                  :default     => nil,
+                  :short_form  => '-o',
+                  :long_form   => '--policy POLICY_UUID',
+                  :description => 'Show only nodes bound by this policy instance',
+                  :uuid_is     => 'not_allowed',
+                  :required    => false
+                }
+            ],
+            :get => [
+                { :name        => :hw_id,
+                  :default     => nil,
+                  :short_form  => '-i',
+                  :long_form   => '--hw_id HW_ID',
+                  :description => 'The HW_ID of the node bound to the active_model instance',
+                  :uuid_is     => 'required',
+                  :required    => false
+                },
+                { :name        => :node_uuid,
+                  :default     => nil,
+                  :short_form  => '-n',
+                  :long_form   => '--node_uuid NODE_UUID',
+                  :description => 'The UUID of the node bound to the active_model instance',
+                  :uuid_is     => 'required',
+                  :required    => false
+                }
+            ],
+            :remove => [
+                { :name        => :hw_id,
+                  :default     => nil,
+                  :short_form  => '-i',
+                  :long_form   => '--hw_id HW_ID',
+                  :description => 'The HW_ID of the node bound to the active_model to remove',
+                  :uuid_is     => 'required',
+                  :required    => false
+                },
+                { :name        => :node_uuid,
+                  :default     => nil,
+                  :short_form  => '-n',
+                  :long_form   => '--node_uuid NODE_UUID',
+                  :description => 'The UUID of the node bound to the active_model to remove',
+                  :uuid_is     => 'required',
+                  :required    => false
+                }
+            ]
+        }.freeze
+      end
+
       def get_all_active_models
         @command = :get_all_active_models
-        # when we get here, should be zero, one, or two elements in the @command_array Array (depending
-        # on whether we included a hardware_id or node_uuid value to match in the command to get all nodes
-        # and, if a hardware_id or node_uuid was provided, whether the user is actually looking for the
-        # logs associated with the active_model bound to that node)
-        get_logs_flag = false
-        if @command_array.size < 3
-          prev_flag = @prev_args.peek(0)
-          hardware_id = @command_array[0] if prev_flag && ['--hw_id','-i'].include?(prev_flag)
-          node_uuid = @command_array[0] if prev_flag && ['--node_uuid','-n'].include?(prev_flag)
-          if @command_array.size == 2 && @command_array[1] == 'logs'
-            get_logs_flag = true
-          end
-        else
-          raise ProjectHanlon::Error::Slice::SliceCommandParsingFailed,
-                "Unexpected arguments found in command #{@command} -> #{@command_array.inspect}"
+        # check for cases where we read too far into the @command_array; if
+        # the argument at the top of the @prev_args stack starts with a '-'
+        # or a '--', then push it back onto the end of the @command_array
+        # for further parsing
+        last_parsed = @prev_args.peek
+        if last_parsed && /^(\-|\-\-).+$/.match(last_parsed)
+          @command_array.unshift(last_parsed)
+          @prev_args.pop
         end
-        # if a hardware ID was passed in, then append it to the @uri_string and return the result,
-        # else just get the list of all nodes and return that result
-        if hardware_id || node_uuid
-          uri = URI.parse(@uri_string + "?hw_id=#{hardware_id}") if hardware_id
-          uri = URI.parse(@uri_string + "?node_uuid=#{node_uuid}") if node_uuid
-          # and get the results of the appropriate RESTful request using that URI
-          result = hnl_http_get(uri)
-          # if user was actually looking for logs, then return the logs
-          if get_logs_flag
-            # convert the result into an active_model instance, then use that instance to
-            # print out the logs for that instance
-            active_model_ref = hash_to_obj(result)
-            return print_object_array(active_model_ref.print_log, "", :style => :table)
-          end
-          # otherwise, return the result as an object array
-          return print_object_array(hash_array_to_obj_array([result]), "Active Model:")
-        end
-        # get the active models from the RESTful API (as an array of objects)
-        uri = URI.parse @uri_string
+        # load the appropriate option items for the subcommand we are handling
+        option_items = command_option_data(:get_all)
+        # parse and validate the options that were passed in as part of this
+        # subcommand (this method will return a UUID value, if present, and the
+        # options map constructed from the @commmand_array)
+        tmp, options = parse_and_validate_options(option_items, :require_all, :banner => "hanlon active_model [get] [all] (options...)")
+        includes_uuid = true if tmp && !['get','all'].include?(tmp)
+        # check for usage errors (the boolean value at the end of this method
+        # call is used to indicate whether the choice of options from the
+        # option_items hash must be an exclusive choice)
+        check_option_usage(option_items, options, includes_uuid, false)
+        # construct the query, and return the results
+        uri_string = @uri_string
+        # add in the policy UUID, if one was provided
+        policy_uuid = options[:policy]
+        add_field_to_query_string(uri_string, "policy", policy_uuid) if policy_uuid && !policy_uuid.empty?
+        # get the nodes from the RESTful API (as an array of objects)
+        uri = URI.parse uri_string
         result = hnl_http_get(uri)
         unless result.blank?
           # convert it to a sorted array of objects (from an array of hashes)
@@ -135,10 +186,45 @@ module ProjectHanlon
 
       def get_active_model_by_uuid
         @command = :get_active_model_by_uuid
-        # the UUID was the last "previous argument"
-        active_model_uuid = @prev_args.peek(0)
-        # setup the proper URI depending on the options passed in
-        uri = URI.parse(@uri_string + '/' + active_model_uuid)
+        # check for cases where we read too far into the @command_array; if
+        # the argument at the top of the @prev_args stack starts with a '-'
+        # or a '--', then push it back onto the end of the @command_array
+        # for further parsing
+        last_parsed = @prev_args.peek
+        if last_parsed && /^(\-|\-\-).+$/.match(last_parsed)
+          @command_array.unshift(last_parsed)
+          @prev_args.pop
+        end
+        # load the appropriate option items for the subcommand we are handling
+        option_items = command_option_data(:get)
+        # parse and validate the options that were passed in as part of this
+        # subcommand (this method will return a UUID value, if present, and the
+        # options map constructed from the @commmand_array)
+        tmp, options = parse_and_validate_options(option_items, :require_all, :banner => "hanlon node [get] [UUID] (options...)",
+                                                  :note => "Note; either the UUID or the HW_ID must be provided (but not both)")
+        active_model_uuid = ( tmp && tmp != "get" ? tmp : nil)
+        options.delete(:hw_id) unless options[:hw_id]
+        # throw an error if both a node UUID value and the :hw_id option were specified
+        # (or if neither was specified)
+        raise ProjectHanlon::Error::Slice::InputError, "Usage Error: one (and only one) of the UUID, the UUID of the bound node, or the Hardware ID of the bound node can be used to specify an active_model" if options[:hw_id] && active_model_uuid
+        raise ProjectHanlon::Error::Slice::InputError, "Usage Error: one of the UUID, the UUID of the bound node, or the Hardware ID of the bound node must be specified" unless options[:hw_id] || options[:node_uuid] || active_model_uuid
+        # check for usage errors (the boolean value at the end of this method call is used to
+        # indicate whether the choice of options from the option_items hash must be an
+        # exclusive choice); will assume that the UUID of the node was provided (or that
+        # an equivalent :hw_id option was provided, if both of these parameters are missing
+        # we wouldn't gotten this far), so the third argument is set to true
+        check_option_usage(option_items, options, true, false)
+        # save the @uri_string to a local variable
+        uri_string = @uri_string
+        # if a active_model_uuid was provided, then add it to the uri_string
+        uri_string << "/#{active_model_uuid}" if active_model_uuid
+        # if either the bound node's UUID or the hardware ID was provided, add them to the
+        # query string
+        hw_id = options[:hw_id]
+        node_uuid = options[:node_uuid]
+        add_field_to_query_string(uri_string, "node_uuid", node_uuid) if node_uuid && !node_uuid.empty?
+        add_field_to_query_string(uri_string, "hw_id", hw_id) if hw_id && !hw_id.empty?
+        uri = URI.parse(uri_string)
         # and get the results of the appropriate RESTful request using that URI
         result = hnl_http_get(uri)
         # finally, based on the options selected, print the results

--- a/core/slice/node.rb
+++ b/core/slice/node.rb
@@ -64,18 +64,21 @@ module ProjectHanlon
         # handles the lines where a UUID is passed in as part of a "get_node_by_uuid" command
         commands[:get].delete(/^(?!^(all|\-\-help|\-h|\{\}|\{.*\}|nil)$)\S+$/)
         # then add a slightly different version of this line back in; one that incorporates
-        # the other flags we might pass in as part of a "get_all_nodes" command
-        commands[:get][/^(?!^(all|\-\-hw_id|\-i|\-\-bmc|\-f|\-\-field|\-b|\-\-username|\-u|\-\-password|\-p|\-\-help|\-h|\{\}|\{.*\}|nil)$)\S+$/] = "get_node_by_uuid"
+        # the other flags we might pass in as part of a "get_all_nodes" or "get_node_by_uuid" command
+        commands[:get][/^(?!^(all|\-\-hw_id|\-i|\-\-policy|\-o|\-\-bmc|\-f|\-\-field|\-b|\-\-username|\-u|\-\-password|\-p|\-\-help|\-h|\{\}|\{.*\}|nil)$)\S+$/] = "get_node_by_uuid"
         #  add in a couple of lines to that handle those flags properly
-        [["-f", "--field"], ["-i", "--hw_id"],["-u", "--username"],["-p", "--password"],["-b", "--bmc"]].each { |val|
-          commands[:get][val] = "get_all_nodes"
+        commands[:get][["-o", "--policy"]] = "get_all_nodes"
+        [["-f", "--field"],["-i", "--hw_id"],["-u", "--username"],["-p", "--password"],["-b", "--bmc"]].each { |val|
+          commands[:get][val] = "get_node_by_uuid"
         }
+        # modify the update ":default" method to handle the exception locally
+        commands[:update][:default] = "update_node"
         # and add a handler for the 'rebind' commands
         commands[:rebind] = {
             ["--help", "-h"]                => "node_help",
             /^(?!^(all|\-\-help|\-h)$)\S+$/ => {
-                :else                           => "rebind_node",
-                :default                        => "rebind_node"
+                :else     => "rebind_node",
+                :default  => "rebind_node"
             }
         }
         commands
@@ -84,46 +87,30 @@ module ProjectHanlon
       def all_command_option_data
         {
             :get_all => [
-                { :name        => :field,
+                { :name        => :policy,
                   :default     => nil,
-                  :short_form  => '-f',
-                  :long_form   => '--field FIELD_NAME',
-                  :description => 'The fieldname (attributes or hardware_id) to get',
-                  :uuid_is     => 'not_allowed',
-                  :required    => false
-                },
-                { :name        => :bmc,
-                  :default     => nil,
-                  :short_form  => '-b',
-                  :long_form   => '--bmc [POWER_CMD]',
-                  :description => 'Get/set the power-state of the specified node',
-                  :uuid_is     => 'not_allowed',
-                  :required    => false
-                },
-                { :name        => :ipmi_username,
-                  :default     => nil,
-                  :short_form  => '-u',
-                  :long_form   => '--username USERNAME',
-                  :description => 'The IPMI username',
-                  :uuid_is     => 'not_allowed',
-                  :required    => false
-                },
-                { :name        => :ipmi_password,
-                  :default     => nil,
-                  :short_form  => '-p',
-                  :long_form   => '--password PASSWORD',
-                  :description => 'The IPMI password',
+                  :short_form  => '-o',
+                  :long_form   => '--policy POLICY_UUID',
+                  :description => 'Show only nodes bound by this policy instance',
                   :uuid_is     => 'not_allowed',
                   :required    => false
                 }
             ],
             :get => [
+                { :name        => :hw_id,
+                  :default     => nil,
+                  :short_form  => '-i',
+                  :long_form   => '--hw_id HW_ID',
+                  :description => 'The hardware ID of the node to get.',
+                  :uuid_is     => 'required',
+                  :required    => false
+                },
                 { :name        => :field,
                   :default     => nil,
                   :short_form  => '-f',
                   :long_form   => '--field FIELD_NAME',
                   :description => 'The fieldname (attributes or hardware_id) to get',
-                  :uuid_is     => 'not_allowed',
+                  :uuid_is     => 'required',
                   :required    => false
                 },
                 { :name        => :bmc,
@@ -131,7 +118,7 @@ module ProjectHanlon
                   :short_form  => '-b',
                   :long_form   => '--bmc',
                   :description => 'Get the BMC (power) status of the specified node',
-                  :uuid_is     => 'not_allowed',
+                  :uuid_is     => 'required',
                   :required    => false
                 },
                 { :name        => :ipmi_username,
@@ -139,7 +126,7 @@ module ProjectHanlon
                   :short_form  => '-u',
                   :long_form   => '--username USERNAME',
                   :description => 'The IPMI username',
-                  :uuid_is     => 'not_allowed',
+                  :uuid_is     => 'required',
                   :required    => false
                 },
                 { :name        => :ipmi_password,
@@ -147,17 +134,25 @@ module ProjectHanlon
                   :short_form  => '-p',
                   :long_form   => '--password PASSWORD',
                   :description => 'The IPMI password',
-                  :uuid_is     => 'not_allowed',
+                  :uuid_is     => 'required',
                   :required    => false
                 }
             ],
             :update => [
+                { :name        => :hw_id,
+                  :default     => nil,
+                  :short_form  => '-i',
+                  :long_form   => '--hw_id HW_ID',
+                  :description => 'The hardware ID of the node to update.',
+                  :uuid_is     => 'not_allowed',
+                  :required    => false
+                },
                 { :name        => :bmc,
                   :default     => nil,
                   :short_form  => '-b',
                   :long_form   => '--bmc POWER_CMD',
-                  :description => 'Get the BMC (power) status of the specified node',
-                  :uuid_is     => 'required',
+                  :description => 'Set the BMC (power) status of the specified node',
+                  :uuid_is     => 'not_allowed',
                   :required    => true
                 },
                 { :name        => :ipmi_username,
@@ -165,7 +160,7 @@ module ProjectHanlon
                   :short_form  => '-u',
                   :long_form   => '--username USERNAME',
                   :description => 'The IPMI username',
-                  :uuid_is     => 'required',
+                  :uuid_is     => 'not_allowed',
                   :required    => false
                 },
                 { :name        => :ipmi_password,
@@ -173,7 +168,7 @@ module ProjectHanlon
                   :short_form  => '-p',
                   :long_form   => '--password PASSWORD',
                   :description => 'The IPMI password',
-                  :uuid_is     => 'required',
+                  :uuid_is     => 'not_allowed',
                   :required    => false
                 }
             ],
@@ -204,11 +199,13 @@ module ProjectHanlon
           begin
             # load the option items for this command (if they exist) and print them
             option_items = command_option_data(command)
-            # need to handle the usage for the 'rebind' command a bit differently; the
-            # UUID can be included or the Hardware ID can be included, but not both
-            # (so the UUID is optional, but required if the Hardware ID is not included)
+            # need to handle the usage for the 'get', 'update', and 'rebind' commands
+            # a bit differently; the UUID can be included or the Hardware ID can be included,
+            # but not both (so the UUID is optional, but required if the Hardware ID is
+            # not included)
             optparse_options = { }
-            optparse_options[:banner] = "hanlon node #{command} [UUID] (options...)" if command == 'rebind'
+            optparse_options[:banner] = "hanlon node #{command} [UUID] (options...)" if ['get', 'update', 'rebind'].include?(command)
+            optparse_options[:note] = "Note; either a UUID or a HW_ID must be provided (but not both)" if ['get', 'update', 'rebind'].include?(command)
             print_command_help(command, option_items, optparse_options)
             return
           rescue
@@ -222,61 +219,54 @@ module ProjectHanlon
       def get_node_help
         return ["Node Slice: used to view the current list of nodes (or node details)".red,
                 "Node Commands:".yellow,
-                "\thanlon node [get] [all] [--hw_id,-i HW_ID (options...)]  " + "Display list of nodes".yellow,
-                "\thanlon node [get] (UUID)                                 " + "Display details for a node".yellow,
-                "\thanlon node [get] (UUID) [--field,-f FIELD]              " + "Display node's field values".yellow,
+                "\thanlon node [get] [all]                                        " + "Display list of nodes".yellow,
+                "\thanlon noce [get] [all] --policy,-o POLICY_UUID                " + "Display nodes bound by policy instance".yellow,
+                "\thanlon node [get] (UUID)                                       " + "Display details for a node".yellow,
+                "\thanlon node [get] --hw_id,i (HW_ID)                            " + "\t(alt form; by Hardware ID)".yellow,
+                "\thanlon node [get] (UUID) [--field,-f FIELD]                    " + "Display node's field values".yellow,
+                "\thanlon node [get] --hw_id,i (HW_ID) [--field,-f FIELD]         " + "\t(alt form; by Hardware ID)".yellow,
                 "\t    Note; the FIELD value can be either 'attributes' or 'hardware_ids'",
-                "\thanlon node [get] (UUID) [--bmc,-b]                      " + "Display node's power status".yellow,
-                "\thanlon node update (UUID) --bmc,-b (BMC_POWER_CMD)       " + "Run a BMC-related power command".yellow,
+                "\thanlon node [get] (UUID) [--bmc,-b]                            " + "Display node's power status".yellow,
+                "\thanlon node [get] --hw_id,i (HW_ID) [--bmc,-b]                 " + "\t(alt form; by Hardware ID)".yellow,
+                "\thanlon node update (UUID) --bmc,-b (BMC_POWER_CMD)             " + "Run a BMC-related power command".yellow,
+                "\thanlon node update --hw_id,i (HW_ID) --bmc,-b (BMC_POWER_CMD)  " + "\t(alt form; by Hardware ID)".yellow,
                 "\t    Note; the BMC_POWER_CMD must be 'on', 'off', 'reset', 'cycle' or 'softShutdown'",
-                "\thanlon node rebind (UUID) [-c]                           " + "Set/cancel node rebinding on next boot".yellow,
-                "\thanlon node rebind --hw_id,i (HW_ID) [-c]                " + "Set/cancel node rebinding on next boot".yellow,
-                "\thanlon node --help                                       " + "Display this screen".yellow].join("\n")
+                "\thanlon node rebind (UUID) [-c]                                 " + "Set/cancel node rebinding on next boot".yellow,
+                "\thanlon node rebind --hw_id,i (HW_ID) [-c]                      " + "\t(alt form; by Hardware ID)".yellow,
+                "\thanlon node --help                                             " + "Display this screen".yellow].join("\n")
 
       end
 
       def get_all_nodes
         # Get all node instances and print/return
         @command = :get_all_nodes
-        # grab the hardware ID (if one was supplied); throw an error if the flag
-        # was found but the value was not
-        if @prev_args.peek(0) == "-i" || @prev_args.peek(0) == "--hw_id"
-          hardware_id = @command_array.shift
-          raise ProjectHanlon::Error::Slice::InputError, "Usage Error: missing hardware ID value" unless hardware_id && !hardware_id.empty?
-        else
-          hw_id_index = @command_array.index('-i') || @command_array.index('--hw_id')
-          if hw_id_index
-            hw_id_val = @command_array[hw_id_index + 1]
-            hardware_id = @command_array[hw_id_index + 1] if hw_id_val && !['-p','-password','-u','-user','-b','-bmc'].include?(hw_id_val)
-            raise ProjectHanlon::Error::Slice::InputError, "Usage Error: missing hardware ID value" unless hardware_id && !hardware_id.empty?
-            @command_array.delete_at(hw_id_index + 1); @command_array.delete_at(hw_id_index)
-            @command_array.unshift(@prev_args.pop)
-          end
+        # check for cases where we read too far into the @command_array; if
+        # the argument at the top of the @prev_args stack starts with a '-'
+        # or a '--', then push it back onto the end of the @command_array
+        # for further parsing
+        last_parsed = @prev_args.peek
+        if last_parsed && /^(\-|\-\-).+$/.match(last_parsed)
+          @command_array.unshift(last_parsed)
+          @prev_args.pop
         end
-        # if a hardware ID was passed in, then use it to select the appropriate node and print the result...
-        # (note; in this case might also have to handle the same options used in the "get_node_by_uuid"
-        # method, except the UUID will not be required since we've supplied a hardware_id instead)
-        if hardware_id
-          # load the appropriate option items for the subcommand we are handling
-          option_items = command_option_data(:get_all)
-          # parse and validate the options that were passed in as part of this
-          # subcommand (this method will return a UUID value, if present, and the
-          # options map constructed from the @commmand_array)
-          node_uuid, options = parse_and_validate_options(option_items, :require_all, :banner => "hanlon node [get] (options...)")
-          options[:hw_id] = hardware_id
-          # check to see if an option was passed in for a power-control command
-          bmc_power_cmd = options[:bmc]
-          if bmc_power_cmd && options[:bmc].class == String
-            return update_power_state(@uri_string, node_uuid, options)
-          end
-          return print_node_cmd_output(@uri_string, options)
-        end
-        # catch situations where user included the BMC flag, but didn't include a hardware_id
-        if (['-b','-bmc'].include?(@prev_args.peek(0))) || !(['-b','-bmc'] & @command_array).empty?
-          raise ProjectHanlon::Error::Slice::InputError, "Usage Error: a hardware ID value must be specified to get/set BMC power-state"
-        end
+        # load the appropriate option items for the subcommand we are handling
+        option_items = command_option_data(:get_all)
+        # parse and validate the options that were passed in as part of this
+        # subcommand (this method will return a UUID value, if present, and the
+        # options map constructed from the @commmand_array)
+        tmp, options = parse_and_validate_options(option_items, :require_all, :banner => "hanlon node [get] [all] (options...)")
+        includes_uuid = true if tmp && !['get','all'].include?(tmp)
+        # check for usage errors (the boolean value at the end of this method
+        # call is used to indicate whether the choice of options from the
+        # option_items hash must be an exclusive choice)
+        check_option_usage(option_items, options, includes_uuid, false)
+        # construct the query, and return the results
+        uri_string = @uri_string
+        # add in the policy UUID, if one was provided
+        policy_uuid = options[:policy]
+        add_field_to_query_string(uri_string, "policy", policy_uuid) if policy_uuid && !policy_uuid.empty?
         # get the nodes from the RESTful API (as an array of objects)
-        uri = URI.parse @uri_string
+        uri = URI.parse uri_string
         result = hnl_http_get(uri)
         unless result.blank?
           # convert it to a sorted array of objects (from an array of hashes)
@@ -289,21 +279,40 @@ module ProjectHanlon
 
       def get_node_by_uuid
         @command = :get_node_by_uuid
-        includes_uuid = false
+        # check for cases where we read too far into the @command_array; if
+        # the argument at the top of the @prev_args stack starts with a '-'
+        # or a '--', then push it back onto the end of the @command_array
+        # for further parsing
+        last_parsed = @prev_args.peek
+        if last_parsed && /^(\-|\-\-).+$/.match(last_parsed)
+          @command_array.unshift(last_parsed)
+          @prev_args.pop
+        end
         # load the appropriate option items for the subcommand we are handling
         option_items = command_option_data(:get)
         # parse and validate the options that were passed in as part of this
         # subcommand (this method will return a UUID value, if present, and the
         # options map constructed from the @commmand_array)
-        node_uuid, options = parse_and_validate_options(option_items, :require_all, :banner => "hanlon node [get] (UUID) (options...)")
-        raise ProjectHanlon::Error::Slice::InputError, "Usage Error: missing UUID value" if /^\-/.match(node_uuid)
-        print_node_cmd_output("#{@uri_string}/#{node_uuid}", options)
-      end
-
-      def add_field_to_query_string(uri_string, fieldname, value)
-        # if there's already a query string in this uri_string, then
-        # just append to it, otherwise start a new query string
-        /^[a-z]+:\/\/[^\?]+\?\S+$/.match(uri_string) ? uri_string << "&#{fieldname}=#{value}" : uri_string << "?#{fieldname}=#{value}"
+        tmp, options = parse_and_validate_options(option_items, :require_all, :banner => "hanlon node [get] [UUID] (options...)",
+                                                  :note => "Note; either the UUID or the HW_ID must be provided (but not both)")
+        node_uuid = ( tmp && tmp != "get" ? tmp : nil)
+        options.delete(:hw_id) unless options[:hw_id]
+        # throw an error if both a node UUID value and the :hw_id option were specified
+        # (or if neither was specified)
+        raise ProjectHanlon::Error::Slice::InputError, "Usage Error: either the UUID or Hardware ID can be used to specify a node, but not both" if options[:hw_id] && node_uuid
+        raise ProjectHanlon::Error::Slice::InputError, "Usage Error: a UUID or Hardware ID for node must be specified" unless options[:hw_id] || node_uuid
+        # check for usage errors (the boolean value at the end of this method call is used to
+        # indicate whether the choice of options from the option_items hash must be an
+        # exclusive choice); will assume that the UUID of the node was provided (or that
+        # an equivalent :hw_id option was provided, if both of these parameters are missing
+        # we wouldn't gotten this far), so the third argument is set to true
+        check_option_usage(option_items, options, true, false)
+        # save the @uri_string to a local variable
+        uri_string = @uri_string
+        # if a node_uuid was provided, then add it to the uri_string
+        uri_string << "/#{node_uuid}" if node_uuid
+        # and print the results
+        print_node_cmd_output(uri_string, options)
       end
 
       def print_node_cmd_output(uri_string, options)
@@ -355,34 +364,48 @@ module ProjectHanlon
         # construct our initial uri_string using the input node_uuid (or not, if a hw_id was specified
         # instead of a node_uuid)
         hw_id ? uri_string = "#{uri_string}/power" : uri_string = "#{uri_string}/#{node_uuid}/power"
-        # if a power command was passed in, then process it and return the result
-        uri = URI.parse(uri_string)
-        if ['on','off','reset','cycle','softShutdown'].include?(power_cmd)
-          body_hash = {
-              "power_command" => power_cmd,
-          }
-          body_hash["ipmi_username"] = ipmi_username if ipmi_username && !ipmi_username.empty?
-          body_hash["ipmi_password"] = ipmi_password if ipmi_password && !ipmi_password.empty?
-          body_hash["hw_id"] = hw_id if hw_id && !hw_id.empty?
-          json_data = body_hash.to_json
-          result = hnl_http_post_json_data(uri, json_data)
-          print_object_array([result], "Node Power Result:", :style => :table)
+        # if a power command was passed in, then we're setting the power state
+        # of a node, so process the request and return the result
+        if power_cmd && !power_cmd.empty?
+          if ['on','off','reset','cycle','softShutdown'].include?(power_cmd)
+            body_hash = { }
+            body_hash["power_command"]= power_cmd if power_cmd && !power_cmd.empty?
+            body_hash["ipmi_username"] = ipmi_username if ipmi_username && !ipmi_username.empty?
+            body_hash["ipmi_password"] = ipmi_password if ipmi_password && !ipmi_password.empty?
+            body_hash["hw_id"] = hw_id if hw_id && !hw_id.empty?
+            json_data = body_hash.to_json
+            uri = URI.parse(uri_string)
+            result = hnl_http_post_json_data(uri, json_data)
+            print_object_array([result], "Node Power Result:", :style => :table)
+          else
+            raise ProjectHanlon::Error::Slice::CommandFailed, "Unrecognized power command [#{power_cmd}]; valid values are 'on', 'off', 'reset', 'cycle' or 'softShutdown'"
+          end
         else
-          raise ProjectHanlon::Error::Slice::CommandFailed, "Unrecognized power command [#{power_cmd}]; valid values are 'on', 'off', 'reset', 'cycle' or 'softShutdown'"
+          # should never get here, but just in case...
+          raise ProjectHanlon::Error::Slice::CommandFailed, "Power command not found while attempting to set power state"
         end
       end
 
       def update_node
         @command = :update_node
-        includes_uuid = false
+        # check for cases where we read too far into the @command_array; if
+        # the argument at the top of the @prev_args stack starts with a '-'
+        # or a '--', then push it back onto the end of the @command_array
+        # for further parsing
+        last_parsed = @prev_args.peek
+        if last_parsed && /^(\-|\-\-).+$/.match(last_parsed)
+          @command_array.unshift(last_parsed)
+          @prev_args.pop
+        end
         # load the appropriate option items for the subcommand we are handling
         option_items = command_option_data(:update)
         # parse and validate the options that were passed in as part of this
         # subcommand (this method will return a UUID value, if present, and the
         # options map constructed from the @commmand_array)
-        node_uuid, options = parse_and_validate_options(option_items, :require_all, :banner => "hanlon node update UUID (options...)")
+        tmp, options = parse_and_validate_options(option_items, :require_all, :banner => "hanlon node update [UUID] (options...)")
+        node_uuid = tmp if tmp && tmp != "update"
         includes_uuid = true if node_uuid
-        raise ProjectHanlon::Error::Slice::InputError, "Usage Error: must specify a node UUID to update" unless includes_uuid
+        raise ProjectHanlon::Error::Slice::InputError, "Usage Error: must specify a node (by UUID or Hardware ID) to update" unless includes_uuid || options[:hw_id]
         update_power_state(@uri_string, node_uuid, options)
       end
 

--- a/web/api/api_active_model_v1.rb
+++ b/web/api/api_active_model_v1.rb
@@ -141,6 +141,8 @@ module Hanlon
             raise ProjectHanlon::Error::Slice::InvalidCommand, "only one node selection parameter ('policy_uuid', 'hw_id' or 'node_uuid') may be used" if num_sel_params > 1
             # if either a node_uuid or a hw_id was provided, return the details for the active_model bound to the node
             # with that node_id, otherwise just return the list of all active_models
+            active_models = nil
+            active_model_selection_array = []
             if hw_id || node_uuid
               engine = ProjectHanlon::Engine.instance
               if hw_id
@@ -162,14 +164,13 @@ module Hanlon
               # otherwise a Policy UUID was supplied, then determine which nodes were bound to
               # active_models by that policy and use them to define a node selection array
               active_models = SLICE_REF.get_object("active_models", :active)
-              active_model_selection_array = []
               active_models.each { |active_model|
                 active_model_selection_array << active_model.uuid if active_model.root_policy == policy.uuid
               }
             end
-            active_models = SLICE_REF.get_object("active_models", :active)
+            active_models = SLICE_REF.get_object("active_models", :active) unless active_models
             # if a node selection array was defined, use it to filter the list of nodes returned
-            active_models.select! { |active_model| active_model_selection_array.include?(active_model.uuid) } if active_model_selection_array
+            active_models.select! { |active_model| active_model_selection_array.include?(active_model.uuid) } unless active_model_selection_array.empty?
             slice_success_object(SLICE_REF, :get_all_active_models, active_models, :success_type => :generic)
           end     # end GET /active_model
 

--- a/web/api/api_active_model_v1.rb
+++ b/web/api/api_active_model_v1.rb
@@ -120,7 +120,11 @@ module Hanlon
 
           # GET /active_model
           # Retrieve list of active_models (or if a 'node_uuid' or 'hw_id' is provided, retrieve the details
-          # for the active_model bound to the specified node instead)
+          # for the active_model bound to the specified node instead; or if a 'policy' is provided, show the
+          # list of active_models created by that policy).
+          #
+          # Note that although the :node_uuid, :hw_id, and :policy are all shown as optional, there can be
+          # only one (or none) of these specified in a valid request to this endpoint
           desc "Retrieve a list of all active_model instances"
           params do
             optional :node_uuid, type: String, desc: "The (Hanlon-assigned) UUID of the bound node."
@@ -131,7 +135,10 @@ module Hanlon
             node_uuid = params[:node_uuid] if params[:node_uuid]
             hw_id = params[:hw_id].upcase if params[:hw_id]
             policy_uuid = params[:policy] if params[:policy]
-            raise ProjectHanlon::Error::Slice::InvalidCommand, "only one node selection parameter ('hw_id' or 'node_uuid') may be used" if (hw_id && node_uuid)
+            # count the number of non-nil optional inputs received; there
+            # should only be one in a valid request
+            num_sel_params = [node_uuid, hw_id, policy_uuid].select { |val| val }.size
+            raise ProjectHanlon::Error::Slice::InvalidCommand, "only one node selection parameter ('policy_uuid', 'hw_id' or 'node_uuid') may be used" if num_sel_params > 1
             # if either a node_uuid or a hw_id was provided, return the details for the active_model bound to the node
             # with that node_id, otherwise just return the list of all active_models
             if hw_id || node_uuid

--- a/web/api/api_node_v1.rb
+++ b/web/api/api_node_v1.rb
@@ -177,7 +177,6 @@ module Hanlon
               # otherwise a Policy UUID was supplied, then determine which nodes were bound to
               # active_models by that policy and use them to define a node selection array
               active_models = SLICE_REF.get_object("active_models", :active)
-              node_selection_array = []
               active_models.each { |active_model|
                 node_selection_array << active_model.node_uuid if active_model.root_policy == policy.uuid
               }

--- a/web/api/api_node_v1.rb
+++ b/web/api/api_node_v1.rb
@@ -164,6 +164,7 @@ module Hanlon
             uuid = params[:uuid].upcase if params[:uuid]
             policy_uuid = params[:policy]
             raise ProjectHanlon::Error::Slice::InputError, "Usage Error: either a Hardware ID or a Policy UUID can be provided as a filter, but not both" if params[:uuid] && params[:policy]
+            node_selection_array = []
             if uuid
               # if a Hardware ID was supplied, then return the node with that Hardware ID
               node = ProjectHanlon::Engine.instance.lookup_node_by_hw_id({:uuid => uuid, :mac_id => []})
@@ -183,7 +184,7 @@ module Hanlon
             end
             nodes = SLICE_REF.get_object("nodes", :node)
             # if a node selection array was defined, use it to filter the list of nodes returned
-            nodes.select! { |node| node_selection_array.include?(node.uuid) } if node_selection_array
+            nodes.select! { |node| node_selection_array.include?(node.uuid) } unless node_selection_array.empty?
             slice_success_object(SLICE_REF, :get_all_nodes, nodes, :success_type => :generic)
           end       # end GET /node
 


### PR DESCRIPTION
The changes in this pull request add the ability to retrieve a list of active_models based on the policy that was used to create them or a list of nodes based on the policy that was used to create the active_model instances that are bound to them. From the CLI, this change shows up as a new option to the `get_all_active_models` and `get_all_nodes` methods, as can be seen, below:
```bash
$ hanlon active_model get all --help
Usage: hanlon active_model [get] [all] (options...)
    -o, --policy POLICY_UUID         Show only nodes bound by this policy instance
    -h, --help                       Display this screen.
$ hanlon node get all --help
Usage: hanlon node [get] [all] (options...)
    -o, --policy POLICY_UUID         Show only nodes bound by this policy instance
    -h, --help                       Display this screen.
$ 
``` 
While we were cleaning up these two methods, we also cleaned up the way the options to these two slices are processed. Specifically, we moved the handling of the flags used to select a specific active_model/node to the appropriate method in each of those slices (the `get_node_by_uuid` and `get_active_model_by_uuid` methods, respectively) and moved the handling of the flags used to query the power-state of a node to the `get_node_by_uuid` method (from the `get_all_nodes` method).

Of course, changes were also made to the RESTful APIs for these two slices to support this new capability. The only changes necessary were to add a single new parameter to each of the top-level GET operations, so it's a non-breaking change to the API.

Finally, we made some changes to improve error handling in the CLI and added an extra note to the end of the help output for each of these methods to help users understand which of the fields are required, which are optional, and which are mutually exclusive. Hopefully the new help output is clearer to new users.