### PR TITLE
Resolves #359 (hanlon node option for --list-by-hw-id)

### DIFF
--- a/core/node.rb
+++ b/core/node.rb
@@ -48,11 +48,19 @@ class ProjectHanlon::Node < ProjectHanlon::Object
     engine.node_status(self)
   end
 
-  def print_header
-    return "UUID", "Last Checkin", "Status", "Tags"
+  def print_header(additional_fields = nil)
+    header_fields = ["UUID", "Last Checkin", "Status", "Tags"]
+    additional_fields.each { |field|
+      if field == 'hardware_id'
+        header_fields << 'Hardware ID'
+      else
+        header_fields << field.split('_').map(&:capitalize).join(' ')
+      end
+    } if additional_fields
+    header_fields
   end
 
-  def print_items
+  def print_items(additional_fields = nil)
     # filter out the hardware ID related tag (using the pattern for an SMBIOS UUID)
     # from the list of tags to display
     temp_tags = @tags.reject { |item| /[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/.match(item) }
@@ -71,11 +79,20 @@ class ProjectHanlon::Node < ProjectHanlon::Object
       else
         status = "U"
     end
-    return @uuid, pretty_time(time_diff), status, "[#{temp_tags.join(",")}]"
+    return_vals = @uuid, pretty_time(time_diff), status, "[#{temp_tags.join(",")}]"
+    additional_fields.each { |field|
+      if field == 'hardware_id'
+        val = "[#{@hw_id.join(",")}]"
+      else
+        val = @attributes_hash[field]
+      end
+      return_vals << (val ? val : 'N/A')
+    } if additional_fields
+    return_vals
   end
 
   def print_item_header
-    return "UUID", "Last Checkin", "Status", "Tags", "Hardware IDs"
+    return "UUID", "Last Checkin", "Status", "Tags", "Hardware ID"
   end
 
   def print_item
@@ -84,7 +101,7 @@ class ProjectHanlon::Node < ProjectHanlon::Object
     temp_tags = @tags.reject { |item| /[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/.match(item) }
     temp_tags = ["n/a"] if temp_tags == [] || temp_tags == nil
     return @uuid, Time.at(@timestamp.to_i).strftime("%m-%d-%y %H:%M:%S"), @status,
-        "[#{temp_tags.join(",")}]", "[#{@hw_id.join(", ")}]"
+        "[#{temp_tags.join(",")}]", "[#{@hw_id.join(",")}]"
   end
 
   def line_color

--- a/core/slice.rb
+++ b/core/slice.rb
@@ -506,8 +506,13 @@ class ProjectHanlon::Slice < ProjectHanlon::Object
         end
       else
         object_array.each do |obj|
-          print_array << obj.print_items
-          header = obj.print_header
+          if obj.class.instance_method(:print_items).arity == -1
+            print_array << obj.print_items(options[:additional_fields])
+            header = obj.print_header(options[:additional_fields])
+          else
+            print_array << obj.print_items
+            header = obj.print_header
+          end
           line_colors << obj.line_color
           header_color = obj.header_color
         end

--- a/core/slice/node.rb
+++ b/core/slice/node.rb
@@ -277,7 +277,7 @@ module ProjectHanlon
         uri_string = @uri_string
         # add in the policy UUID, if one was provided
         policy_uuid = options[:policy]
-        additional_attribs = options[:attribs].split(',')
+        additional_attribs = options[:attribs].split(',') if options[:attribs]
         add_field_to_query_string(uri_string, "policy", policy_uuid) if policy_uuid && !policy_uuid.empty?
         # get the nodes from the RESTful API (as an array of objects)
         uri = URI.parse uri_string


### PR DESCRIPTION
The changes in this PR add an additional flag to the `hanlon node get all ...` CLI command that provides the user with the ability to specify additional attributes that they would like to include in the CLI output of that command:
```bash
$ hanlon node get all --help
Usage: hanlon node [get] [all] (options...)
    -o, --policy POLICY_UUID         Show only nodes bound by this policy instance
    -a, --attribs ATTRIBS_LIST       Show additional attributes from ATTRIBS_LIST in output
    -h, --help                       Display this screen.
$ 
```
The new flag (the `-a` or `--attribs` flag) takes a single argument, which is assumed to be a comma-separated list of attributes that should be appended to the normal output for this command (which, by default, shows the UUID of the node, the elapsed time since it's last checkin, it's status flag, and it's tags). These attributes can be any of the attributes from the `@attributes_hash` for the node or the special field name `hardware_id` (which, naturally, maps to the node's `@hw_id`). As an example, here's the output of a `hanlon get all ...` command using this new flag:
```bash
$ hanlon node -a 'macaddress_eth0,hardware_id'
Discovered Nodes
         UUID           Last Checkin  Status                                       Tags                                        Macaddress Eth0                Hardware ID
1133M9gkRo4hWsA9R4l7hI  50361.8 min   B       [ebig_disk,000C29C3ADA0,cpus_1,IntelCorporation,memsize_2GiB,nics_1,vmware_vm]  00:0C:29:C3:AD:A0  [564D4061-72A6-C9A7-CD40-A17045C3ADA0]
mxes1vHbiQwEEPxvbZ7BY   31577.6 min   B       [big_disk,000C2995CD68,cpus_1,IntelCorporation,memsize_1GiB,nics_1,vmware_vm]   00:0C:29:95:CD:68  [564DF1A7-1B78-F6B1-55F9-774F8C95CD68]
26DOHJ019Md8snOL1oGmeG  2142.3 min    B       [big_disk,000C29AECE0B,cpus_1,IntelCorporation,memsize_2GiB,nics_1,vmware_vm]   00:0C:29:AE:CE:0B  [564DC8E3-22AC-0D46-6001-50B003AECE0B]
$ 
```
And, just to prove that this flag can be used in combination with the `-o,--policy` flag we just added to this same CLI command:
```bash
$ hanlon node -a 'macaddress_eth0,hardware_id' -o 5hp
Discovered Nodes
         UUID           Last Checkin  Status                                      Tags                                        Macaddress Eth0                Hardware ID
26DOHJ019Md8snOL1oGmeG  2142.4 min    B       [big_disk,000C29AECE0B,cpus_1,IntelCorporation,memsize_2GiB,nics_1,vmware_vm]  00:0C:29:AE:CE:0B  [564DC8E3-22AC-0D46-6001-50B003AECE0B]
$ 
```