### PR TITLE
Set Gemfile declared version of Ruby to match the Dockerfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '2.2.1'
+ruby '2.2'
 
 gem 'uuid'
 gem 'base62'


### PR DESCRIPTION
The changes in this PR set the version of Ruby declared in the Gemfile declared to match the version declared in the Dockerfile (otherwise the docker build fails with an error because bundler cannot be run on newer versions of the ruby:2.2-wheezy container). We could have done this either by specifying a less-specific version of Ruby in the Gemfile or a more-specific version of Ruby in the Dockerfile; we chose to do the former over the latter.