### PR TITLE
Set Gemfile declared version of Ruby to match the Dockerfile (take 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION 2.3.0
 
-FROM ruby:2.2.2-wheezy
+FROM ruby:2.2.1-wheezy
 MAINTAINER Joseph Callen <jcpowermac@gmail.com>
 
 # Install the required dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION 2.3.0
 
-FROM ruby:2.2-wheezy
+FROM ruby:2.2.2-wheezy
 MAINTAINER Joseph Callen <jcpowermac@gmail.com>
 
 # Install the required dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '2.2.2'
+ruby '2.2.1'
 
 gem 'uuid'
 gem 'base62'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '2.2'
+ruby '2.2.2'
 
 gem 'uuid'
 gem 'base62'


### PR DESCRIPTION
Set Gemfile declared version of ruby and Dockerfile declared version of ruby to match, down to the minor build number (otherwise the docker build fails with an error because bundler cannot be run on newer versions of the ruby:2.2.2-wheezy container