### PR TITLE
Adding an option for custom Red Hat partitioning

### DIFF
--- a/core/model/esxi/5/kickstart.erb
+++ b/core/model/esxi/5/kickstart.erb
@@ -1,6 +1,6 @@
 # Thanks to William Lam for being the guru
 accepteula
-clearpart --firstdisk --overwritevmfs
+clearpart --alldrives --overwritevmfs
 install --firstdisk --overwritevmfs
 rootpw <%= @root_password %>
 reboot

--- a/core/model/esxi/5_dhcp/kickstart.erb
+++ b/core/model/esxi/5_dhcp/kickstart.erb
@@ -1,6 +1,6 @@
 # Thanks to William Lam for being the guru
 accepteula
-clearpart --firstdisk --overwritevmfs
+clearpart --alldrives --overwritevmfs
 install --firstdisk --overwritevmfs
 network --bootproto=dhcp --device=vmnic0
 rootpw <%= @root_password %>

--- a/core/model/redhat.rb
+++ b/core/model/redhat.rb
@@ -25,6 +25,7 @@ module ProjectHanlon
         @description = "Redhat Generic Model"
         # Metadata vars
         @hostname_prefix = nil
+        @partition_scheme = nil
         # State / must have a starting state
         @current_state = :init
         # Image UUID
@@ -44,11 +45,11 @@ module ProjectHanlon
                 :description => "node hostname prefix (will append node number)"
             },
             "@domainname" => {
-              :default     => "localdomain",
-              :example     => "example.com",
-              :validation  => '^[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9](\.[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])*$',
-              :required    => true,
-              :description => "local domain name (will be used in /etc/hosts file)"
+                :default     => "localdomain",
+                :example     => "example.com",
+                :validation  => '^[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9](\.[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])*$',
+                :required    => true,
+                :description => "local domain name (will be used in /etc/hosts file)"
             },
             "@root_password" => {
                 :default     => "test1234",
@@ -57,6 +58,15 @@ module ProjectHanlon
                 :required    => true,
                 :description => "root password (> 8 characters)"
             },
+        }
+        @opt_metadata_hash = {
+            "@partition_scheme" => {
+                :default     => "",
+                :example     => "",
+                :validation  => '',
+                :required    => false,
+                :description => "YAML formatted partitioning scheme"
+            }
         }
       end
 
@@ -276,6 +286,14 @@ module ProjectHanlon
 
       def api_svc_uri
         "http://#{config.hanlon_server}:#{config.api_port}#{config.websvc_root}"
+      end
+
+      def partition_scheme
+        if @partition_scheme
+          @partition_scheme['partition_scheme']
+        else
+          'autopart'
+        end
       end
 
       def generate_kickstart(policy_uuid)

--- a/core/model/redhat.rb
+++ b/core/model/redhat.rb
@@ -290,7 +290,7 @@ module ProjectHanlon
 
       def partition_scheme
         if @partition_scheme
-          @partition_scheme['partition_scheme']
+          @partition_scheme
         else
           'autopart'
         end

--- a/core/model/redhat/6/kickstart.erb
+++ b/core/model/redhat/6/kickstart.erb
@@ -18,8 +18,8 @@ bootloader --location=mbr --driveorder=sda --append=crashkernel=auto rhgb quiet
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
+clearpart --all
 zerombr
-clearpart --all --initlabel
 autopart
 # reboot automatically
 reboot

--- a/core/model/redhat/6/kickstart.erb
+++ b/core/model/redhat/6/kickstart.erb
@@ -14,10 +14,6 @@ authconfig --enableshadow --passalgo=sha512 --enablefingerprint
 selinux --disabled
 timezone --utc America/Denver
 bootloader --location=mbr --driveorder=sda --append=crashkernel=auto rhgb quiet
-# The following is the partition information you requested
-# Note that any partitions you deleted are not expressed
-# here so unless you clear all partitions first, this is
-# not guaranteed to work
 clearpart --all
 zerombr
 autopart
@@ -34,4 +30,4 @@ curl <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/kickstart/end
 curl -o /tmp/hanlon_postinstall.sh <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/postinstall/inject
 echo bash /tmp/hanlon_postinstall.sh >> /etc/rc.local
 chmod +x /tmp/hanlon_postinstall.sh
-############
+%end

--- a/core/model/redhat/7/kickstart.erb
+++ b/core/model/redhat/7/kickstart.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Kickstart for RHEL/CentOS 6
-# see: http://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html
+# Kickstart for RHEL 7
+# see: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
 
 install
 url --url=http://<%= config.hanlon_server %>:<%= config.api_port %><%= config.websvc_root %>/image/os/<%= @image_uuid %>
@@ -14,10 +14,6 @@ authconfig --enableshadow --passalgo=sha512 --enablefingerprint
 selinux --disabled
 timezone --utc America/Denver
 bootloader --location=mbr --driveorder=sda --append=crashkernel=auto rhgb quiet
-# The following is the partition information you requested
-# Note that any partitions you deleted are not expressed
-# here so unless you clear all partitions first, this is
-# not guaranteed to work
 clearpart --all
 zerombr
 autopart
@@ -37,5 +33,4 @@ echo bash /tmp/hanlon_postinstall.sh >> /etc/rc.local
 chmod +x /tmp/hanlon_postinstall.sh
 # This line needs to be added otherwise rc.local will not execute on boot
 chmod +x /etc/rc.d/rc.local
-############
 %end

--- a/core/model/redhat/7/kickstart.erb
+++ b/core/model/redhat/7/kickstart.erb
@@ -18,8 +18,8 @@ bootloader --location=mbr --driveorder=sda --append=crashkernel=auto rhgb quiet
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
+clearpart --all
 zerombr
-clearpart --all --initlabel
 autopart
 # reboot automatically
 reboot

--- a/core/model/redhat/7/kickstart.erb
+++ b/core/model/redhat/7/kickstart.erb
@@ -16,7 +16,8 @@ timezone --utc America/Denver
 bootloader --location=mbr --driveorder=sda --append=crashkernel=auto rhgb quiet
 clearpart --all
 zerombr
-autopart
+# Partitioning scheme
+<%= partition_scheme %>
 # reboot automatically
 reboot
 

--- a/core/model/vmware_esxi.rb
+++ b/core/model/vmware_esxi.rb
@@ -51,7 +51,7 @@ module ProjectHanlon
         @enable_vsan             = "" 
         @vsan_uuid               = UUID.generate
         @packages                = []
-	@configure_disk_to_local = ""
+        @configure_disk_to_local = ""
         # Metadata
         @req_metadata_hash       = {
             "@esx_license"             => { :default     => "",
@@ -122,11 +122,11 @@ module ProjectHanlon
                                             :validation  => '^[a-zA-Z\d-]{3,}$',
                                             :required    => false,
                                             :description => "Optional for broker use: the vCenter Cluster to place ESXi node in" },
-            "@enable_vsan"       => { :default     => "False",
-                                           :example     => "",
-                                           :validation  => '',
-                                           :required    => false,
-                                           :description => "Join vSAN cluster and create vSAN disk groups" },
+            "@enable_vsan"             => { :default     => "False",
+                                            :example     => "",
+                                            :validation  => '',
+                                            :required    => false,
+                                            :description => "Join vSAN cluster and create vSAN disk groups" },
             "@vsan_uuid"               => { :default     => "",
                                             :example     => "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
                                             :validation  => '^[a-z\d]{8}-[a-z\d]{4}-[a-z\d]{4}-[a-z\d]{4}-[a-z\d]{12}$',
@@ -137,7 +137,7 @@ module ProjectHanlon
                                             :validation  => '',
                                             :required    => false,
                                             :description => "Optional for broker use: the vCenter Cluster to place ESXi node in" },
-	    "@configure_disk_to_local" => { :default     => "False",
+            "@configure_disk_to_local" => { :default     => "False",
                                             :example     => "",
                                             :validation  => '',
                                             :required    => false,

--- a/scripts/minimize-rhel-iso.sh
+++ b/scripts/minimize-rhel-iso.sh
@@ -70,7 +70,7 @@ ISO_MOUNT='/mnt/cdrom'
 
 # cleanup from previous build if it was interrupted
 if [[ ! -d ${BUILD_DIR} ]]; then
-	rm -rf ${BUILD_DIR}
+    rm -rf ${BUILD_DIR}
 fi
 
 if [[ -e /etc/yum.repos.d/rhel-dvd.repo ]]; then


### PR DESCRIPTION
This PR adds the ability to specify a custom partitioning scheme in the Red Hat model.  If one is not specified, `autopart` is used as default as it was previously.

An example optional yaml file:
```
---
hostname_prefix: node
domainname: localdomain
root_password: test1234
partition_scheme: |
  part /boot --ondisk=sda --size=512  --fstype=ext3
  part swap  --ondisk=sda --size=4096 --fstype=swap
  part pv.01 --ondisk=sda --size=1 --grow
  volgroup vg_root pv.01
  logvol / --vgname=vg_root --size=32768 --name=lv_root --fstype=xfs --grow
  ignoredisk --only-use=sda
```

Other changes:
* The `--initlabel` option is deprecated in RHEL 7 and has been removed from the kickstart.
* The kickstarts for esxi were updated to ensure that all partitions are cleared prior to an installation.
* Various minor file formatting updates.