### PR TITLE
Specify line number when creating a new policy

### DIFF
--- a/core/policies.rb
+++ b/core/policies.rb
@@ -92,7 +92,7 @@ module ProjectHanlon
         #puts "#{policy_index} == #{(@p_table.count - 1)}"
         # throw an error if the new_index is not within the bounds of the policy table
         if new_index > (@p_table.count - 1) || new_index < 0
-          raise ProjectHanlon::Error::Slice::InputError, "New line number '#{new_index}' is not valid; should be an between 0 and #{@p_table.count - 1}"
+          raise ProjectHanlon::Error::Slice::InputError, "Line number '#{new_index}' is not valid; should be an between 0 and #{@p_table.count - 1}"
         end
         # skip operation if new_index is the same as the existing index or out of the bounds
         # of the policy table

--- a/core/slice/policy.rb
+++ b/core/slice/policy.rb
@@ -102,6 +102,14 @@ module ProjectHanlon
                   :uuid_is     => 'not_allowed',
                   :required    => true
                 },
+                { :name        => :tags,
+                  :default     => nil,
+                  :short_form  => '-t',
+                  :long_form   => '--tags TAG{,TAG,TAG}',
+                  :description => 'Policy tags. Comma delimited.',
+                  :uuid_is     => 'not_allowed',
+                  :required    => true
+                },
                 { :name        => :broker_uuid,
                   :default     => 'none',
                   :short_form  => '-b',
@@ -110,13 +118,13 @@ module ProjectHanlon
                   :uuid_is     => 'not_allowed',
                   :required    => false
                 },
-                { :name        => :tags,
+                { :name        => :line_number,
                   :default     => nil,
-                  :short_form  => '-t',
-                  :long_form   => '--tags TAG{,TAG,TAG}',
-                  :description => 'Policy tags. Comma delimited.',
+                  :short_form  => '-n',
+                  :long_form   => '--number LINE_NO',
+                  :description => 'Line number in policy rules table [default: nil].',
                   :uuid_is     => 'not_allowed',
-                  :required    => true
+                  :required    => false
                 },
                 { :name        => :enabled,
                   :default     => false,
@@ -188,7 +196,7 @@ module ProjectHanlon
                   :default     => nil,
                   :short_form  => '-n',
                   :long_form   => '--new-line-number NEW_NUM',
-                  :description => 'Change policy rule number.',
+                  :description => 'New line number in policy rules table.',
                   :uuid_is     => 'required',
                   :required    => true
                 }
@@ -254,8 +262,6 @@ module ProjectHanlon
         # call is used to indicate whether the choice of options from the
         # option_items hash must be an exclusive choice)
         check_option_usage(option_items, options, includes_uuid, false)
-        # check the values that were passed in
-        policy = new_object_from_template_name(POLICY_PREFIX, options[:template])
         # assign default values for (missing) optional parameters
         options[:maximum] = "0" if !options[:maximum]
         options[:broker_uuid] = "none" if !options[:broker_uuid]
@@ -268,6 +274,7 @@ module ProjectHanlon
             "model_uuid" => options[:model_uuid],
             "tags" => options[:tags],
             "broker_uuid" => options[:broker_uuid],
+            "line_number" => options[:line_number],
             "enabled" => options[:enabled],
             "maximum" => options[:maximum]
         }.to_json

--- a/web/api/api_policy_v1.rb
+++ b/web/api/api_policy_v1.rb
@@ -214,7 +214,14 @@ module Hanlon
             # if a line number was provided, move the policy to that position in
             # the policy rules table
             if line_number
-              policy_rules.move_policy_to_idx(policy.uuid, line_number.to_i)
+              begin
+                policy_rules.move_policy_to_idx(policy.uuid, line_number.to_i)
+              rescue ProjectHanlon::Error::Slice::InputError => e
+                # if got here, could not create policy at stated position, so remove
+                # the policy we already created from the system and rethrow the error
+                get_data_ref.delete_object(policy)
+                raise e
+              end
               policy.line_number = line_number
             else
               # Issue 125 Fix - add policy serial number & bind_counter to rest api

--- a/web/api/api_policy_v1.rb
+++ b/web/api/api_policy_v1.rb
@@ -157,6 +157,7 @@ module Hanlon
           #     model_uuid        | String | The UUID of the model to use             |         | Default: unavailable
           #     tags              | String | The (comma-separated) list of tags       |         | Default: unavailable
           #     broker_uuid       | String | The UUID of the broker to use            |         | Default: "none"
+          #     line_number       | String | The line number in the policy table      |         | Default: nil
           #     enabled           | String | A flag indicating if policy is enabled   |         | Default: "false"
           #     maximum           | String | The maximum_count for the policy         |         | Default: "0"
           desc "Create a new policy instance"
@@ -166,6 +167,7 @@ module Hanlon
             requires "model_uuid", type: String, desc: "The model to use (by UUID)"
             requires "tags", type: String, desc: "The tags to match against"
             optional "broker_uuid", type: String, default: "none", desc: "The broker to use (by UUID)"
+            optional "line_number", type: String, default: nil, desc: "Line number in the policy table for new policy"
             optional "enabled", type: String, default: "false", desc: "Enabled when created?"
             optional "maximum", type: String, default: "0", desc: "Max. number to match against"
           end
@@ -176,6 +178,7 @@ module Hanlon
             model_uuid = params["model_uuid"]
             broker_uuid = params["broker_uuid"] unless params["broker_uuid"] == "none"
             tags = params["tags"]
+            line_number = params["line_number"]
             enabled = params["enabled"]
             maximum = params["maximum"]
             # check for errors in inputs
@@ -189,6 +192,8 @@ module Hanlon
               broker = SLICE_REF.get_object("broker_by_uuid", :broker, broker_uuid)
               raise ProjectHanlon::Error::Slice::InvalidUUID, "Invalid Broker UUID [#{broker_uuid}]" unless (broker && (broker.class != Array || broker.length > 0)) || broker_uuid == "none"
             end
+            line_number = line_number.strip if line_number
+            raise ProjectHanlon::Error::Slice::InputError, "Index '#{line_number}' is not an integer" if line_number && !/^[+-]?\d+$/.match(line_number)
             # split the tags and determine how they should be matched to a node for this policy (either an 'and' or an 'or')
             tags, match_using = split_tags(tags)
             raise ProjectHanlon::Error::Slice::MissingTags, "Must provide at least one tag ['tag(,tag)']" unless tags.count > 0
@@ -206,8 +211,16 @@ module Hanlon
             # Add policy
             policy_rules         = ProjectHanlon::Policies.instance
             raise(ProjectHanlon::Error::Slice::CouldNotCreate, "Could not create Policy") unless policy_rules.add(policy)
+            # if a line number was provided, move the policy to that position in
+            # the policy rules table
+            if line_number
+              policy_rules.move_policy_to_idx(policy.uuid, line_number.to_i)
+              policy.line_number = line_number
+            else
+              # Issue 125 Fix - add policy serial number & bind_counter to rest api
+              policy.line_number = policy.row_number
+            end
             # Issue 125 Fix - add policy serial number & bind_counter to rest api
-            policy.line_number = policy.row_number
             policy.bind_counter = policy.current_count
             slice_success_object(SLICE_REF, :create_policy, policy, :success_type => :created)
           end     # end POST /policy
@@ -366,7 +379,7 @@ module Hanlon
                 broker = SLICE_REF.get_object("broker_by_uuid", :broker, broker_uuid)
                 raise ProjectHanlon::Error::Slice::InvalidUUID, "Invalid Broker UUID [#{broker_uuid}]" unless (broker && (broker.class != Array || broker.length > 0)) || broker_uuid == "none"
               end
-              new_line_number = (new_line_number ? new_line_number.strip : nil)
+              new_line_number = new_line_number.strip if new_line_number
               raise ProjectHanlon::Error::Slice::InputError, "New index '#{new_line_number}' is not an integer" if new_line_number && !/^[+-]?\d+$/.match(new_line_number)
               if enabled
                 raise ProjectHanlon::Error::Slice::InputError, "Enabled flag must have a value of 'true' or 'false'" if enabled != "true" && enabled != "false"


### PR DESCRIPTION
The changes in this pull request give users the ability to specify the line number in the policy rules table that should be used for a new policy when it is being created. Previously, this would require creating a new policy (which would be placed at the end of the policy rules table by default), then moving that policy to the line number the where it should be placed. Now this same sequence of operations can be completed in one POST to the policy endpoint. For example, let's assume that the policy table for your system looks something like this:
```bash
$ hanlon policy
Policies:
#  Enabled             Label                              Tags                           Model Label          #/Max  Counter           UUID
0  true     coreos-607.0.0               [564DC8E3-22AC-0D46-6001-50B003AECE0B]  coreos-607.0.0               2/-    2        2R4R4wfL4hxCYNPQKRGTXU
1  true     rhel-server-7.0-x86_64       [memsize_2GiB,cpus_2]                   rhel-server-7.0-x86_64       0/-    1        6NTcrKduZcP6M0MvXLn1Q8
2  true     ubuntu-12.04.5-server-amd64  [memsize_2GiB]                          ubuntu-12.04.5-server-amd64  0/-    1        5bDT0ghZxnAZzwMWcdv7wm
3  true     discover_only                [vmware_vm]                             discover_only                0/-    4        5PgSXOvI3uIzqcqodxMPTs
$ 
```
with the new functionality added in this pull request, you can use the new `-n,--number` CLI flag (or the corresponding `line_number` parameter in the RESTful APIs JSON body) to add a new policy to that policy rules table as follows:
```bash
$ hanlon policy add -p linux_deploy -l tmp-policy -m 21g -t 564D7989-10A3-6557-43FE-1EC2B2A936AF -n 0 -e true
Policy Created:
 UUID =>  F2yBIAnDQ0CVXaaJd9tJ2
 Line Number =>  0
 Label =>  tmp-policy
 Enabled =>  true
 Template =>  linux_deploy
 Description =>  Policy for deploying a Linux-based operating system.
 Tags =>  [564D7989-10A3-6557-43FE-1EC2B2A936AF]
 Match Using =>  and
 Model Label =>  coreos-607.0.0
 Broker Target =>  none
 Currently Bound =>  0
 Maximum Bound =>  0
 Bound Counter =>  0

$ 
```
and the resulting policy rules table will look something like this:
```bash
$ hanlon policy
Policies:
#  Enabled             Label                              Tags                           Model Label          #/Max  Counter           UUID
0  true     tmp-policy                   [564D7989-10A3-6557-43FE-1EC2B2A936AF]  coreos-607.0.0               0/-    0        F2yBIAnDQ0CVXaaJd9tJ2
1  true     coreos-607.0.0               [564DC8E3-22AC-0D46-6001-50B003AECE0B]  coreos-607.0.0               2/-    2        2R4R4wfL4hxCYNPQKRGTXU
2  true     rhel-server-7.0-x86_64       [memsize_2GiB,cpus_2]                   rhel-server-7.0-x86_64       0/-    1        6NTcrKduZcP6M0MvXLn1Q8
3  true     ubuntu-12.04.5-server-amd64  [memsize_2GiB]                          ubuntu-12.04.5-server-amd64  0/-    1        5bDT0ghZxnAZzwMWcdv7wm
4  true     discover_only                [vmware_vm]                             discover_only                0/-    4        5PgSXOvI3uIzqcqodxMPTs
$ 
```
as you can see, the new policy has been added to the start of the policy rules table instead of the end. It should also be noted here that if the line number passed to the system is out of bounds (in this example, less than zero or greater than three), an error will be thrown and the policy rules table will be left unchanged.