### PR TITLE
Correcting the redhat model to fix opt_metadata_hash

### DIFF
--- a/core/model/coreos.rb
+++ b/core/model/coreos.rb
@@ -38,7 +38,6 @@ module ProjectHanlon
         # Default: no cloud config
         @cloud_config = nil
         @final_state = :os_complete
-        from_hash(hash) unless hash == nil
         @req_metadata_hash = {
           "@hostname_prefix" => {
             :default     => "node",
@@ -71,6 +70,7 @@ module ProjectHanlon
             :description  => "A yaml containing CoreOS cloud config options"
           }
         }
+        from_hash(hash) unless hash == nil
       end
 
       def callback

--- a/core/model/redhat.rb
+++ b/core/model/redhat.rb
@@ -35,7 +35,6 @@ module ProjectHanlon
         # Enable agent brokers for this model
         @broker_plugin = :agent
         @final_state = :os_complete
-        from_hash(hash) unless hash == nil
         @req_metadata_hash = {
             "@hostname_prefix" => {
                 :default     => "node",
@@ -68,6 +67,7 @@ module ProjectHanlon
                 :description => "YAML formatted partitioning scheme"
             }
         }
+        from_hash(hash) unless hash == nil
       end
 
       def callback


### PR DESCRIPTION
The opt_metadata_hash was not being returned through the API and was
causing a failure when trying to supply the partition_scheme parameter.