### PR TITLE
Adds the concept of a 'default policy' to Hanlon

### DIFF
--- a/core/policies.rb
+++ b/core/policies.rb
@@ -46,13 +46,17 @@ module ProjectHanlon
         # throw an error if the new_index is not within the bounds of the policy table
         # (the size of the table less one if no default policy is defined; the size of
         # the table less two if there is a default policy defined)
-        ProjectHanlon::Policies.instance.get_default_policy ? offset = 1 : offset = 0
+        default_uuid = ProjectHanlon::Policies.instance.get_default_policy
         # if we're moving (instead of inserting) then the limit is one less than
         # if we're adding a new policy to the table
-        offset = offset + 1 if move_flag
+        if move_flag
+          default_uuid ? offset = 2 : offset = 1
+        else
+          default_uuid ? offset = 1 : offset = 0
+        end
         max_index = @p_table.count - offset
         if new_index > max_index
-          if offset == 1
+          if default_uuid
             raise ProjectHanlon::Error::Slice::InputError, "Line number '#{new_index}' is not valid; should be between 0 and #{max_index}"
           else
             raise ProjectHanlon::Error::Slice::InputError, "Cannot move policies below default policy; new line number must be between 0 and #{max_index}"

--- a/core/policy/base.rb
+++ b/core/policy/base.rb
@@ -3,7 +3,7 @@
 
 module ProjectHanlon
   module PolicyTemplate
-    class Base< ProjectHanlon::Object
+    class Base < ProjectHanlon::Object
       include(ProjectHanlon::Logging)
 
       attr_accessor :label

--- a/core/policy/boot_local.rb
+++ b/core/policy/boot_local.rb
@@ -1,10 +1,10 @@
 # ProjectHanlon Policy Base class
 # Root abstract
-require 'policy/base'
+require 'policy/no_op'
 
 module ProjectHanlon
   module PolicyTemplate
-    class BootLocal < ProjectHanlon::PolicyTemplate::Base
+    class BootLocal < ProjectHanlon::PolicyTemplate::NoOp
       include(ProjectHanlon::Logging)
 
       # @param hash [Hash]

--- a/core/policy/discover_only.rb
+++ b/core/policy/discover_only.rb
@@ -1,10 +1,10 @@
 # ProjectHanlon Policy Base class
 # Root abstract
-require 'policy/base'
+require 'policy/no_op'
 
 module ProjectHanlon
   module PolicyTemplate
-    class DiscoverOnly < ProjectHanlon::PolicyTemplate::Base
+    class DiscoverOnly < ProjectHanlon::PolicyTemplate::NoOp
       include(ProjectHanlon::Logging)
 
       # @param hash [Hash]

--- a/core/policy/no_op.rb
+++ b/core/policy/no_op.rb
@@ -1,0 +1,86 @@
+# ProjectHanlon NoOp Policy Base class
+# Root abstract
+require 'policy/base'
+
+module ProjectHanlon
+  module PolicyTemplate
+    class NoOp < ProjectHanlon::PolicyTemplate::Base
+      include(ProjectHanlon::Logging)
+
+      attr_accessor :is_default
+
+      # @param hash [Hash]
+      def initialize(hash)
+        super(hash)
+        @hidden = true
+        @template = :no_op
+        @description = "Base class for 'no-op' models in Hanlon."
+        @is_default = false
+
+        from_hash(hash) unless hash == nil
+      end
+
+      def print_header
+        if @bound
+          return "Label", "State", "Node UUID", "Broker", "Bind #", "UUID"
+        else
+          if @is_template
+            return "Template", "Description"
+          else
+            return "#", "Enabled", "Label", "Tags", "Model Label", "#/Max", "Counter", "UUID"
+          end
+        end
+      end
+
+      def print_items
+        if @bound
+          broker_name = @broker ? @broker.name : "none"
+          return @label, @model.current_state.to_s, @node_uuid, broker_name, @model.counter.to_s, @uuid
+        else
+          tag_string = (is_default ? '**default**' : "[#{get_tag_string}]")
+          if @is_template
+            return @template.to_s, @description.to_s
+          else
+            max_num = @maximum_count.to_i == 0 ? '-' : @maximum_count
+            return @line_number.to_s, @enabled.to_s, @label, tag_string, @model.label.to_s, "#{@bind_counter}/#{max_num}", @model.counter.to_s, @uuid
+          end
+        end
+      end
+
+      def print_item
+        if @bound
+          broker_name = @broker ? @broker.name : "none"
+          [@uuid,
+           @label,
+           @template.to_s,
+           @node_uuid,
+           @model.label.to_s,
+           @model.name.to_s,
+           @model.current_state.to_s,
+           broker_name,
+           @model.counter.to_s,
+           Time.at(@bind_timestamp).strftime("%H:%M:%S %m-%d-%Y")]
+        else
+          broker_name = @broker ? @broker.name : "none"
+          tag_string = (is_default ? '**default**' : "[#{get_tag_string}]")
+          [@uuid,
+           #line_number.to_s,
+           @line_number.to_s,
+           @label,
+           @enabled.to_s,
+           @template.to_s,
+           @description,
+           tag_string,
+           @match_using,
+           @model.label.to_s,
+           broker_name,
+           #current_count.to_s,
+           @bind_counter.to_s,
+           @maximum_count.to_s,
+           @model.counter.to_s]
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
The changes in this pull request add a new concept to Hanlon, that of a "default policy".  The intent of adding a default policy to the policy rules table is to provide users with a mechanism for creating a policy that will match any node, regardless of how it is tagged, if no other policies in the policy rules table match.  There are a number of restrictions on default policies that are imposed by the code in this pull request, namely:

* there can only be one default policy in the system at a time; any attempt to add a second default policy will result in an error being thrown
* that default policy can only be created using a "noop policy" template (either a `discover_only` or a `boot_local` policy template); attempts to create a default policy based on any other type of policy will fail
* the default policy is always the last policy in the policy table; attempts to add a default policy earlier in the policy table, to create other policies at locations lower than the default policy, or to update other policies to move them lower in the table than the default policy will result in an error being thrown
* default policies, once created, cannot be updated (they can only be removed)
* attempting to set a broker ID, the enabled flag, or maximum number of bindings when creating a default policy for the system will result in an error; none of these constraints make sense when defining the default policy for the system
* similarly, attempting to specify a line number when creating a default policy will result in an error; the only valid location for a default policy is the last line of the policy rules table.

Creating a policy and defining it as the default policy for the system is simply a matter of using the new `-d,--default` flag with the `hanlon policy add ...` command (from the CLI) or setting the value of the `is_default` parameter in the RESTful JSON body of a POST to the `/policy` endpoint to true (if using the RESTful API directly).