### PR TITLE
Changes Docker to support cassandra

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN gem install bundle \
 	&& cd /home/hanlon \
 	&& bundle install --system
 
-ENV TEST_MODE true
 ENV LANG en_US.UTF-8
 ENV WIMLIB_IMAGEX_USE_UTF8 true
 ENV HANLON_WEB_PATH /home/hanlon/web

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,18 @@ RUN gem install bundle \
 	&& cd /home/hanlon \
 	&& bundle install --system
 
-# Hanlon by default runs at TCP 8026
-EXPOSE 8026
-
 ENV TEST_MODE true
 ENV LANG en_US.UTF-8
 ENV WIMLIB_IMAGEX_USE_UTF8 true
+ENV HANLON_WEB_PATH /home/hanlon/web
 
-WORKDIR /home/hanlon/web
-CMD (cd /home/hanlon && ./hanlon_init -j '{"hanlon_static_path": "'$HANLON_STATIC_PATH'", "hanlon_subnets": "'$HANLON_SUBNETS'", "hanlon_server": "'$DOCKER_HOST'", "persist_host": "'$MONGO_PORT_27017_TCP_ADDR'"}' ) && ./run-puma.sh
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+WORKDIR /home/hanlon
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+# Hanlon by default runs at TCP 8026
+EXPOSE 8026
+CMD []

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ "$PERSIST_MODE" = "cassandra" ]
+if [ "$PERSIST_MODE" = "@cassandra" ]
 then
   cat <<EOF > ${HANLON_WEB_PATH}/config/cassandra_db.conf
 hosts: $CASSANDRA_PORT_9042_TCP_ADDR
@@ -9,7 +9,7 @@ keyspace: 'project_hanlon'
 repl_strategy: $REPL_STRATEGY
 repl_factor: $REPL_FACTOR
 EOF
-  ./hanlon_init -j '{"persist_mode": "@cassandra", "persist_options_file": "cassandra_db.conf", "hanlon_static_path": "'$HANLON_STATIC_PATH'", "hanlon_subnets": "'$HANLON_SUBNETS'", "hanlon_server": "'$DOCKER_HOST'"}'
+  ./hanlon_init -j '{"persist_mode": "'$PERSIST_MODE'", "persist_options_file": "cassandra_db.conf", "hanlon_static_path": "'$HANLON_STATIC_PATH'", "hanlon_subnets": "'$HANLON_SUBNETS'", "hanlon_server": "'$DOCKER_HOST'"}'
 
 else
   ./hanlon_init -j '{"hanlon_static_path": "'$HANLON_STATIC_PATH'", "hanlon_subnets": "'$HANLON_SUBNETS'", "hanlon_server": "'$DOCKER_HOST'", "persist_host": "'$MONGO_PORT_27017_TCP_ADDR'"}'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+if [ "$PERSIST_MODE" = "cassandra" ]
+then
+  cat <<EOF > ${HANLON_WEB_PATH}/config/cassandra_db.conf
+hosts: $CASSANDRA_PORT_9042_TCP_ADDR
+port: 9042
+keyspace: 'project_hanlon'
+repl_strategy: $REPL_STRATEGY
+repl_factor: $REPL_FACTOR
+EOF
+  ./hanlon_init -j '{"persist_mode": "@cassandra", "persist_options_file": "cassandra_db.conf", "hanlon_static_path": "'$HANLON_STATIC_PATH'", "hanlon_subnets": "'$HANLON_SUBNETS'", "hanlon_server": "'$DOCKER_HOST'"}'
+
+else
+  ./hanlon_init -j '{"hanlon_static_path": "'$HANLON_STATIC_PATH'", "hanlon_subnets": "'$HANLON_SUBNETS'", "hanlon_server": "'$DOCKER_HOST'", "persist_host": "'$MONGO_PORT_27017_TCP_ADDR'"}'
+fi
+
+cd ${HANLON_WEB_PATH}
+
+PORT=`awk '/api_port/ {print $2}' config/hanlon_server.conf`
+puma -p ${PORT} $@ 2>&1 | tee /tmp/puma.log

--- a/hanlon_init
+++ b/hanlon_init
@@ -43,7 +43,8 @@ module ProjectHanlon
         end
       elsif options[:json_defaults]
         default_params = begin
-          JSON.parse(options[:json_defaults])
+          hash = JSON.parse(options[:json_defaults])
+          hash.each { |k, v| hash[k] = v.gsub(/^@/,'').to_sym if /^@/.match(v) }
         rescue Exception => e
           puts "Could not parse defaults JSON string '#{options[:json_defaults]}': #{e.message}"
           exit 4


### PR DESCRIPTION
Adding modifications that @tjmcs wrote in hanlon_init
Added docker-entrypoint.sh
Changed Dockerfile to for ENTRYPOINT and COPY of docker-entrypoint.sh
This allows parameters to be passed to puma for threading and workers