### PR TITLE
Fixes #394 (Options for IPMI commands)

### DIFF
--- a/core/slice/node.rb
+++ b/core/slice/node.rb
@@ -146,6 +146,14 @@ module ProjectHanlon
                   :description => 'The IPMI password',
                   :uuid_is     => 'required',
                   :required    => false
+                },
+                { :name        => :ipmi_options,
+                  :default     => nil,
+                  :short_form  => '-o',
+                  :long_form   => '--options JSON_STRING',
+                  :description => 'The IPMI options',
+                  :uuid_is     => 'required',
+                  :required    => false
                 }
             ],
             :update => [
@@ -178,6 +186,14 @@ module ProjectHanlon
                   :short_form  => '-p',
                   :long_form   => '--password PASSWORD',
                   :description => 'The IPMI password',
+                  :uuid_is     => 'not_allowed',
+                  :required    => false
+                },
+                { :name        => :ipmi_options,
+                  :default     => nil,
+                  :short_form  => '-o',
+                  :long_form   => '--options JSON_STRING',
+                  :description => 'The IPMI options',
                   :uuid_is     => 'not_allowed',
                   :required    => false
                 }
@@ -335,12 +351,14 @@ module ProjectHanlon
         hw_id = options[:hw_id]
         ipmi_username = options[:ipmi_username]
         ipmi_password = options[:ipmi_password]
+        ipmi_options = options[:ipmi_options]
         raise ProjectHanlon::Error::Slice::InputError, "Usage Error: cannot use the 'field' and 'bmc' options simultaneously" if bmc_power_cmd && selected_option
         if bmc_power_cmd
           uri_string << '/power'
           add_field_to_query_string(uri_string, 'ipmi_username', ipmi_username) if ipmi_username && !ipmi_username.empty?
           add_field_to_query_string(uri_string, 'ipmi_password', ipmi_password) if ipmi_password && !ipmi_password.empty?
           add_field_to_query_string(uri_string, 'hw_id', hw_id) if hw_id && !hw_id.empty?
+          add_field_to_query_string(uri_string, 'ipmi_options', URI.encode(ipmi_options)) if ipmi_options && !ipmi_options.empty?
           uri = URI.parse(uri_string)
           # get the current power state of the node using that URI
           result = hnl_http_get(uri)
@@ -374,6 +392,7 @@ module ProjectHanlon
         power_cmd = options[:bmc]
         ipmi_username = options[:ipmi_username]
         ipmi_password = options[:ipmi_password]
+        ipmi_options = options[:ipmi_options]
         hw_id = options[:hw_id]
         # construct our initial uri_string using the input node_uuid (or not, if a hw_id was specified
         # instead of a node_uuid)
@@ -387,6 +406,7 @@ module ProjectHanlon
             body_hash["ipmi_username"] = ipmi_username if ipmi_username && !ipmi_username.empty?
             body_hash["ipmi_password"] = ipmi_password if ipmi_password && !ipmi_password.empty?
             body_hash["hw_id"] = hw_id if hw_id && !hw_id.empty?
+            body_hash["ipmi_options"] =  ipmi_options if ipmi_options && !ipmi_options.empty?
             json_data = body_hash.to_json
             uri = URI.parse(uri_string)
             result = hnl_http_post_json_data(uri, json_data)

--- a/web/api/api_node_v1.rb
+++ b/web/api/api_node_v1.rb
@@ -78,7 +78,6 @@ module Hanlon
             ipmi_ip_address = node.attributes_hash['mk_ipmi_IP_Address']
             # if we didn't find that IP address in the list of facts for this node, then throw
             # an error (you can't get the power status if the node doesn't have an attached BMC)
-puts options_hash.inspect
             raise ProjectHanlon::Error::Slice::CommandFailed, "BMC for node with UUID [#{node.uuid}] does not exist; power state cannot be determined" unless ipmi_ip_address
             # if we get this far, then grab the IPMI username, password, and preferred IPMI command
             # (freeipmi, ipmitool or, if unspecified, whichever is found first) from the server configuration
@@ -111,7 +110,6 @@ puts options_hash.inspect
             ipmi_ip_address = node.attributes_hash['mk_ipmi_IP_Address']
             # if we didn't find that IP address in the list of facts for this node, then throw
             # an error (you can't get the power status if the node doesn't have an attached BMC)
-puts options_hash.inspect
             raise ProjectHanlon::Error::Slice::CommandFailed, "BMC for node with UUID [#{node.uuid}] does not exist; power state cannot be controlled through node slice" unless ipmi_ip_address
             # check the value of the power_command, throw an error if it's unrecognized
             unless ['on','off','reset','cycle','softShutdown'].include?(power_command)


### PR DESCRIPTION
adds an option for specifying IPMI options to the get power state and update the power state of a node