### PR TITLE
Updating Active Model CLI sort order

### DIFF
--- a/core/slice/active_model.rb
+++ b/core/slice/active_model.rb
@@ -186,7 +186,7 @@ module ProjectHanlon
         result = hnl_http_get(uri)
         unless result.blank?
           # convert it to a sorted array of objects (from an array of hashes)
-          sort_fieldname = 'node_uuid'
+          sort_fieldname = 'label'
           result = hash_array_to_obj_array(expand_response_with_uris(result), sort_fieldname)
         end
         # and print the result


### PR DESCRIPTION
It is much more sane to sort on 'label' instead of 'node_uuid'.