### PR TITLE
Fixes #401 (Node API does not correctly handle letter case for hw_id)

### DIFF
--- a/web/api/api_node_v1.rb
+++ b/web/api/api_node_v1.rb
@@ -236,7 +236,7 @@ module Hanlon
               optional :ipmi_options, type: String, desc: "The IPMI connect options (JSON string)"
             end
             get do
-              uuid = params[:hw_id].upcase if params[:hw_id]
+              uuid = params[:hw_id].upcase
               node = ProjectHanlon::Engine.instance.lookup_node_by_hw_id({:uuid => uuid, :mac_id => []})
               raise ProjectHanlon::Error::Slice::InvalidUUID, "Cannot Find Node with Hardware ID: [#{uuid}]" unless node
               ipmi_args = params.select { |key| ['ipmi_username', 'ipmi_password'].include?(key) }
@@ -269,7 +269,7 @@ module Hanlon
               optional :ipmi_options, type: String, desc: "The IPMI connect options (JSON string)"
             end
             post do
-              uuid = params[:hw_id]
+              uuid = params[:hw_id].upcase
               node = ProjectHanlon::Engine.instance.lookup_node_by_hw_id({:uuid => uuid, :mac_id => []})
               raise ProjectHanlon::Error::Slice::InvalidUUID, "Cannot Find Node with Hardware ID: [#{uuid}]" unless node
               ipmi_args = params.select { |key| ['power_command', 'ipmi_username', 'ipmi_password'].include?(key) }
@@ -299,7 +299,7 @@ module Hanlon
               requires :action, type: String, desc: "The rebinding action to set"
             end
             post do
-              uuid = params[:hw_id]
+              uuid = params[:hw_id].upcase
               node = ProjectHanlon::Engine.instance.lookup_node_by_hw_id({:uuid => uuid, :mac_id => []})
               raise ProjectHanlon::Error::Slice::InvalidUUID, "Cannot Find Node with Hardware ID: [#{uuid}]" unless node
               set_rebinding_action(node, params[:action])
@@ -453,7 +453,7 @@ module Hanlon
               optional :field, type: String, desc: "Name of field to return ('attributes' or 'hardware_id')"
             end
             get do
-              node_uuid = params[:uuid]
+              node_uuid = params[:uuid].upcase
               node = SLICE_REF.get_object("node_with_uuid", :node, node_uuid)
               raise ProjectHanlon::Error::Slice::InvalidUUID, "Cannot Find Node with UUID: [#{node_uuid}]" unless node && (node.class != Array || node.length > 0)
               selected_option = params[:field]
@@ -489,7 +489,7 @@ module Hanlon
                 optional :ipmi_options, type: String, desc: "The IPMI connect options (JSON string)"
               end
               get do
-                node_uuid = params[:uuid]
+                node_uuid = params[:uuid].upcase
                 node = SLICE_REF.get_object("node_with_uuid", :node, node_uuid)
                 raise ProjectHanlon::Error::Slice::InvalidUUID, "Cannot Find Node with UUID: [#{node_uuid}]" unless node && (node.class != Array || node.length > 0)
                 ipmi_args = params.select { |key| ['ipmi_username', 'ipmi_password'].include?(key) }
@@ -522,7 +522,7 @@ module Hanlon
                 optional :ipmi_options, type: String, desc: "The IPMI connect options (JSON string)"
               end
               post do
-                node_uuid = params[:uuid]
+                node_uuid = params[:uuid].upcase
                 node = SLICE_REF.get_object("node_with_uuid", :node, node_uuid)
                 raise ProjectHanlon::Error::Slice::InvalidUUID, "Cannot Find Node with UUID: [#{node_uuid}]" unless node && (node.class != Array || node.length > 0)
                 ipmi_option_string = params[:ipmi_options]
@@ -552,7 +552,7 @@ module Hanlon
                 requires :action, type: String, desc: "The rebinding action to set"
               end
               post do
-                node_uuid = params[:uuid]
+                node_uuid = params[:uuid].upcase
                 node = SLICE_REF.get_object("node_with_uuid", :node, node_uuid)
                 raise ProjectHanlon::Error::Slice::InvalidUUID, "Cannot Find Node with UUID: [#{node_uuid}]" unless node && (node.class != Array || node.length > 0)
                 set_rebinding_action(node, params[:action])

--- a/web/api/api_node_v1.rb
+++ b/web/api/api_node_v1.rb
@@ -453,7 +453,7 @@ module Hanlon
               optional :field, type: String, desc: "Name of field to return ('attributes' or 'hardware_id')"
             end
             get do
-              node_uuid = params[:uuid].upcase
+              node_uuid = params[:uuid]
               node = SLICE_REF.get_object("node_with_uuid", :node, node_uuid)
               raise ProjectHanlon::Error::Slice::InvalidUUID, "Cannot Find Node with UUID: [#{node_uuid}]" unless node && (node.class != Array || node.length > 0)
               selected_option = params[:field]
@@ -489,7 +489,7 @@ module Hanlon
                 optional :ipmi_options, type: String, desc: "The IPMI connect options (JSON string)"
               end
               get do
-                node_uuid = params[:uuid].upcase
+                node_uuid = params[:uuid]
                 node = SLICE_REF.get_object("node_with_uuid", :node, node_uuid)
                 raise ProjectHanlon::Error::Slice::InvalidUUID, "Cannot Find Node with UUID: [#{node_uuid}]" unless node && (node.class != Array || node.length > 0)
                 ipmi_args = params.select { |key| ['ipmi_username', 'ipmi_password'].include?(key) }
@@ -522,7 +522,7 @@ module Hanlon
                 optional :ipmi_options, type: String, desc: "The IPMI connect options (JSON string)"
               end
               post do
-                node_uuid = params[:uuid].upcase
+                node_uuid = params[:uuid]
                 node = SLICE_REF.get_object("node_with_uuid", :node, node_uuid)
                 raise ProjectHanlon::Error::Slice::InvalidUUID, "Cannot Find Node with UUID: [#{node_uuid}]" unless node && (node.class != Array || node.length > 0)
                 ipmi_option_string = params[:ipmi_options]
@@ -552,7 +552,7 @@ module Hanlon
                 requires :action, type: String, desc: "The rebinding action to set"
               end
               post do
-                node_uuid = params[:uuid].upcase
+                node_uuid = params[:uuid]
                 node = SLICE_REF.get_object("node_with_uuid", :node, node_uuid)
                 raise ProjectHanlon::Error::Slice::InvalidUUID, "Cannot Find Node with UUID: [#{node_uuid}]" unless node && (node.class != Array || node.length > 0)
                 set_rebinding_action(node, params[:action])


### PR DESCRIPTION
This PR includes the changes needed to ensure that SMBIOS UUIDs used by Hanlon to identify a node in any of the node commands are all compared as upper-case strings (regardless of whether they were passed in as upper-case only or mixed/lower-case) by "upcasing" all of them when they are extracted from any requests made against the node slice's RESTful API