### PR TITLE
Updating rspec tests to verify SMBIOS UUID

### DIFF
--- a/test/spec/web/api/api_node_spec.rb
+++ b/test/spec/web/api/api_node_spec.rb
@@ -6,7 +6,7 @@ describe 'Hanlon::WebService::Node' do
   include ProjectHanlon::HttpHelper
 
   before(:all) do
-    $hw_id = "TEST#{rand(9)}#{rand(9)}#{rand(9)}#{rand(9)}#{rand(9)}#{rand(9)}#{rand(9)}"
+    $hw_id = UUID.generate
   end
 
   describe 'resource :node' do
@@ -41,7 +41,7 @@ describe 'Hanlon::WebService::Node' do
           expect(parsed['http_err_code']).to eq(200)
           expect(parsed['errcode']).to eq(0)
           # make sure we are getting the same hw_id in return
-          expect(hnl_response['@hw_id']).to include($hw_id)
+          expect(hnl_response['@hw_id']).to include($hw_id.upcase)
           # save the created UUID for later use
           $node_uuid = hnl_response['@uuid']
         end
@@ -64,6 +64,25 @@ describe 'Hanlon::WebService::Node' do
       end
 
     end   # end GET /node
+
+    describe 'GET /node?uuid={smbiosuuid}' do
+      it 'Returns the details for a specific node (by SMBIOS UUID)' do
+        uri = URI.parse(hnl_uri + '/node?uuid=' + $hw_id)
+        # make the request
+        hnl_response, http_response = hnl_http_get(uri, true)
+        # parse the output and validate
+        parsed = JSON.parse(http_response.body)
+        expect(parsed['resource']).to eq('ProjectHanlon::Slice::Node')
+        expect(parsed['command']).to eq('get_node_by_hw_id')
+        expect(parsed['result']).to eq('Ok')
+        expect(parsed['http_err_code']).to eq(200)
+        expect(parsed['errcode']).to eq(0)
+        # make sure we are getting the same hw_id in return
+        expect(hnl_response['@hw_id']).to include($hw_id.upcase)
+        # make sure we are getting the same node
+        expect(hnl_response['@uuid']).to eq($node_uuid)
+      end
+    end   # end GET /node/{uuid}
 
     describe 'resource :power' do
 
@@ -117,6 +136,8 @@ describe 'Hanlon::WebService::Node' do
           expect(parsed['result']).to eq('Ok')
           expect(parsed['http_err_code']).to eq(200)
           expect(parsed['errcode']).to eq(0)
+          # make sure we are getting the same hw_id in return
+          expect(hnl_response['@hw_id']).to include($hw_id.upcase)
           # make sure we are getting the same node
           expect(hnl_response['@uuid']).to eq($node_uuid)
         end

--- a/web/api/api_node_v1.rb
+++ b/web/api/api_node_v1.rb
@@ -196,7 +196,7 @@ module Hanlon
               # if a Hardware ID was supplied, then return the node with that Hardware ID
               node = ProjectHanlon::Engine.instance.lookup_node_by_hw_id({:uuid => uuid, :mac_id => []})
               raise ProjectHanlon::Error::Slice::InvalidUUID, "Cannot Find Node with Hardware ID: [#{uuid}]" unless node
-              return slice_success_object(SLICE_REF, :get_all_nodes, node, :success_type => :generic)
+              return slice_success_object(SLICE_REF, :get_node_by_hw_id, node, :success_type => :generic)
             elsif policy_uuid
               # first find the policy with that UUID (in case the user only passed in a partial
               # UUID as an argument)


### PR DESCRIPTION
This commit adds a couple of checks to make sure the SMBIOS UUID is properly handled when nodes are added and queried.  Also, it didn't make sense to return `get_all_nodes` as the command when we were returning a single node based on hw_id.