### PR TITLE
Fixes #405 (Adding an image as a non-root user using the mount command fails unexpectedly)

### DIFF
--- a/web/api/api_image_v1.rb
+++ b/web/api/api_image_v1.rb
@@ -27,7 +27,8 @@ module Hanlon
 
         rescue_from ProjectHanlon::Error::Slice::MethodNotAllowed,
                     ProjectHanlon::Error::Slice::MissingArgument,
-                    ProjectHanlon::Error::Slice::CouldNotRemove do |e|
+                    ProjectHanlon::Error::Slice::CouldNotRemove,
+                    ProjectHanlon::Error::Slice::CommandFailed do |e|
           Rack::Response.new(
               Hanlon::WebService::Response.new(403, e.class.name, e.message).to_json,
               403,


### PR DESCRIPTION
When adding a new image, Hanlon (by default) attempts to unpack the image ISO file using the `fuseiso` or `7z` commands (in that order). If neither of those commands can be found, then it attempts to unpack the ISO file by mounting it (using the standard `mount` command) and then copying over the contents to a directory under the Hanlon image repository.

The issue this PR resolves involved the edge case where neither the `fuseiso` nor the `7z` command were available and the Hanlon was being run as a non-root user. In those situations, the command by Hanlon run to mount the ISO file is the `sudo -n mount` command, and if there is a password required to run this command as that non-root user, then an error is thrown by that command. Unfortunately, the end-user would have no idea what the actual error was (or that an error had even been thrown) due to the rather cryptic nature of the error returned by the image service. Here's an example of the CLI output seen by the end-user if they encountered this error condition:
```bash
$ cli/hanlon image add -t mk -p /tmp/rancheros-v0.4.1.iso -d /tmp/cscdock-mk-image.tar.bz2 -k ~/.ssh/id_rsa.pub
Attempting to add, please wait...
[image] [add_image] <-Deleted Image Directory, Image Path: /home/hanlon/Hanlon/image/mk/3N0WnIPfIMt7Sxlt0jcXzM

Command help:
hanlon image add (options...)
    -t, --type TYPE                  The type of image (mk, os, win, esxi, or xenserver)
    -p, --path /path/to/iso          The local path to the image ISO
    -n, --name IMAGE_NAME            The logical name to use (required; os images only)
    -v, --version VERSION            The version to use (required; os images only)
    -d, --docker-image /path/to/img  The local path to MK image (required; mk images only)
    -k, --ssh-keyfile /path/to/key   The local path to public key file (optional; mk images only)
    -m, --mk-password PASSWORD       The microkernel password (optional; mk images only)
    -h, --help                       Display this screen.
$ 
```
While it's important to log that the directory that was created (in anticipation of copying over contents from the ISO file after it's mounted) was removed, telling the user that it was removed doesn't leave them with any understanding of what the actual error encountered by Hanlon was. With the changes in this PR, here's the new CLI output for that same error:
```bash
$ cli/hanlon image add -t mk -p /tmp/rancheros-v0.4.1.iso -d /tmp/cscdock-mk-image.tar.bz2 -k ~/.ssh/id_rsa.pub
Attempting to add, please wait...
[image] [add_image] <-Command 'sudo -n mount' failed with error 'sudo: a password is required'

Command help:
hanlon image add (options...)
    -t, --type TYPE                  The type of image (mk, os, win, esxi, or xenserver)
    -p, --path /path/to/iso          The local path to the image ISO
    -n, --name IMAGE_NAME            The logical name to use (required; os images only)
    -v, --version VERSION            The version to use (required; os images only)
    -d, --docker-image /path/to/img  The local path to MK image (required; mk images only)
    -k, --ssh-keyfile /path/to/key   The local path to public key file (optional; mk images only)
    -m, --mk-password PASSWORD       The microkernel password (optional; mk images only)
    -h, --help                       Display this screen.
$ 
```
clearly the second error output is much easier for the user to understand than the first. With the changes in this PR, an error is still logged indicating that the directory was removed in the Hanlon logfile but the output returned back to the user is much more understandable (in terms of exactly what went wrong).