### PR TITLE
Fixes double-quote to single-quote bug introduced in a recent PR

### DIFF
--- a/core/slice/image.rb
+++ b/core/slice/image.rb
@@ -328,7 +328,7 @@ module ProjectHanlon
           when /^#{jpg2_regex}/
             'jpg'
           else
-            mime_type = `file #{file_path} --mime-type`.gsub('\n', '') # Works on linux and mac
+            mime_type = `file #{file_path} --mime-type`.gsub("\n", '') # Works on linux and mac
             raise ProjectHanlon::Error::Slice::InputError, "Filetype could not be detected for '#{file_path}'" if !mime_type
             mime_type.split(':')[1].split('/')[1].gsub('x-', '').gsub(/jpeg/, 'jpg').gsub(/text/, 'txt').gsub(/x-/, '')
         end


### PR DESCRIPTION
Fixes a bug introduced in PR #414 when @Suirtimed replaced the double quotes around the newline string in a `gsub()` call with single quotes. As a result, the newline at the end of the `file` command output that is used to obtain the mime type was not substituted with an empty string and the result (eg. "bzip2\n" for a bzip2 file) doesn't match any of the keys in our new `SUPPORTED_TYPES` array and an error is thrown when it shouldn't be. The changes in this PR switch that string back to a double-quoted string, so the` gsub()` call succeeds and a match is found to one of the supported types.

Prior to the fix in this PR, this is what Hanlon output when I tried to add a Microkernel image:
```bash
$ hanlon image add -t mk -p /tmp/rancheros-v0.4.1.iso -d /tmp/cscdock-mk-image.tar.bz2 -k ~/.ssh/id_rsa.pub
Attempting to add, please wait...
[image] [add_image] <-Unsupported file type 'bzip2
' detected for Docker image '/tmp/cscdock-mk-image.tar.bz2'; supported types are ["tar", "gzip", "bzip2"]

Command help:
hanlon image add (options...)
    -t, --type TYPE                  The type of image (mk, os, win, esxi, or xenserver)
    -p, --path /path/to/iso          The local path to the image ISO
    -n, --name IMAGE_NAME            The logical name to use (required; os images only)
    -v, --version VERSION            The version to use (required; os images only)
    -d, --docker-image /path/to/img  The local path to MK image (required; mk images only)
    -k, --ssh-keyfile /path/to/key   The local path to public key file (optional; mk images only)
    -m, --mk-password PASSWORD       The microkernel password (optional; mk images only)
    -h, --help                       Display this screen.
$ 
```
but with the changes in this PR, the same command succeeds:
```bash
$ hanlon image add -t mk -p /tmp/rancheros-v0.4.1.iso -d /tmp/cscdock-mk-image.tar.bz2 -k ~/.ssh/id_rsa.pub
Attempting to add, please wait...
Image Added:
 UUID =>  2ZFp51HjawjVCMkycMQs2S
 Type =>  MicroKernel Image
 Name/Filename =>  rancheros-v0.4.1.iso
 Status =>  Valid
 Version =>  3.0.0
 Built Time =>  2015-11-20 13:13:31 -0800

$ 
```