### PR TITLE
Fixes #419 (issue with smbios UUID in some hypervisors)

### DIFF
--- a/scripts/winpe/hanlon-discover.ps1
+++ b/scripts/winpe/hanlon-discover.ps1
@@ -196,7 +196,7 @@ Function Invoke-Main {
                 $SmbiosUuid = $firstFlip + "-" + $secondFlip + "-" + $thirdFlip + "-" + $uuidArray[3] + "-" + $uuidArray[4]
             }
             else {
-                $SmbiosUuid = = $ComputerSystemProduct.UUID
+                $SmbiosUuid = $ComputerSystemProduct.UUID
             }
 
 			Write-Debug $SmbiosUuid

--- a/scripts/winpe/hanlon-discover.ps1
+++ b/scripts/winpe/hanlon-discover.ps1
@@ -9,25 +9,6 @@ $HanlonShareName = "Hanlon";
 $DebugPreference = "Continue";
 
 
-
-Function Convert-SmbiosUuid {
-
-Param (
-	[Parameter(Mandatory=$True)]
-	[String]
-	$rawUUID
-)
-
-# Create an array of each half (hyphen delimiter)
-$octets = $rawUUID.Split("-")
-# Create an array of each two-charactere byte (space delimiter)
-$bytes = $octets[0].Split(" ") + $octets[1].Split(" ")
-# Build the final string, piecing together byte by byte
-$prettyUUID = $bytes[0] + $bytes[1] + $bytes[2] + $bytes[3] + "-" + $bytes[4] + $bytes[5] + "-" + $bytes[6] + $bytes[7] + "-" + $bytes[8] + $bytes[9] + "-" + $bytes[10] + $bytes[11] + $bytes[12] + $bytes[13] + $bytes[14] + $bytes[15]
-Return $prettyUUID
-
-}
-
 #When using VirtualBox and Fusion the UUID in the first three sections are "byte flipped".
 #Converted the function in the comments http://intermediaware.com/blog/hack-of-the-day-byte-flipping
 #To use for flipping the bits.
@@ -193,7 +174,7 @@ Function Invoke-Main {
                 $third = [int]("0x"+$uuidArray[2])
                 $thirdFlip =  [Convert]::ToString($(Flip-TwoBytes -value $third), 16)
 
-                $SmbiosUuid = $firstFlip + "-" + $secondFlip + "-" + $thirdFlip + "-" + $uuidArray[3] + "-" + $uuidArray[4]
+                $SmbiosUuid = $($firstFlip + "-" + $secondFlip + "-" + $thirdFlip + "-" + $uuidArray[3] + "-" + $uuidArray[4]).ToUpper()
             }
             else {
                 $SmbiosUuid = $ComputerSystemProduct.UUID

--- a/scripts/winpe/hanlon-discover.ps1
+++ b/scripts/winpe/hanlon-discover.ps1
@@ -35,7 +35,7 @@ Return $prettyUUID
 Function Flip-FourBytes {
 Param (
     [Parameter(Mandatory=$True)]
-    [uint]
+    [uint64]
     $value)
 
     return (($value -band 0x000000FF) -shl 24) -bor (($value -band 0x0000FF00) -shl 8) -bor (($value -band 0x00FF0000) -shr 8) -bor (($value -band 0xFF000000) -shr 24)

--- a/scripts/winpe/hanlon-discover.ps1
+++ b/scripts/winpe/hanlon-discover.ps1
@@ -35,7 +35,7 @@ Return $prettyUUID
 Function Flip-FourBytes {
 Param (
     [Parameter(Mandatory=$True)]
-    [int]
+    [uint]
     $value)
 
     return (($value -band 0x000000FF) -shl 24) -bor (($value -band 0x0000FF00) -shl 8) -bor (($value -band 0x00FF0000) -shr 8) -bor (($value -band 0xFF000000) -shr 24)
@@ -186,7 +186,7 @@ Function Invoke-Main {
             if( $ComputerSystemProduct.Name -like "*virtual*" ) {
                 $uuidArray = $ComputerSystemProduct.UUID.split("-")
 
-                $first = [int]("0x"+$uuidArray[0])
+                $first = [uint64]("0x"+$uuidArray[0])
                 $firstFlip = [Convert]::ToString($(Flip-FourBytes -value $first), 16)
                 $second = [int]("0x"+$uuidArray[1])
                 $secondFlip =  [Convert]::ToString($(Flip-TwoBytes -value $second), 16)


### PR DESCRIPTION
This PR should resolve the issue #419.
Modified script to flip the byte order of the smbios uuid when using VirtualBox or VMware virtual machines.  End to end testing has not been done, only executing the script from a local PowerShell.  