### PR TITLE
Adding docker-compose to automate the containers for Hanlon

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+docker-compose.yml
+hanlon.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+---
+mongo:
+  image: mongo
+  command: mongod --smallfiles
+  volumes: 
+    - "/opt/hanlon/data/db:/data/db"
+
+server:
+  image: "cscdock/hanlon"
+  ports: 
+    - 8026:8026
+  links: 
+    - mongo:mongo
+  privileged: true
+  volumes:
+    - "/opt/hanlon/image:/home/hanlon/image"
+    - "/opt/hanlon/cli/config:/home/hanlon/cli/config"
+  env_file: hanlon.env
+#  environment:
+#    DOCKER_HOST: "${DOCKER_HOST}"
+#    HANLON_SUBNETS: "${HANLON_SUBNETS}"
+
+tftpd:
+  image: "atftpd"
+  links: 
+    - "server:hanlon"
+  ports:
+    - 69:69/udp

--- a/hanlon.env
+++ b/hanlon.env
@@ -1,0 +1,9 @@
+
+# DOCKER_HOST should be configured to your Docker hosts' IP address.
+# DOCKER_HOST=192.168.0.10
+
+
+# HANLON_SUBNETS should be configured to the subnets that you want
+# allowed to access Hanlon services.  This should always include
+# the Docker subnets.
+# HANLON_SUBNETS=172.17.42.1/16,192.168.0.0/24


### PR DESCRIPTION
The Hanlon container requires three other services to run.
The database, typically mongo, tftp and DHCP.  We have created a
container for tftp and use mongo's already available container
on Docker registry.  DHCPd is just easier at this point to run on
the host or an externally so that is not included.

This docker-compose addition will orchestrate the starting of the
required services for Hanlon.

We also added a `.dockerignore` so the container build process
removes those unneeded files.

Show running `docker-compose`
```bash
root@ubuntu-hanlon:~/Hanlon# docker-compose up -d
Creating hanlon_mongo_1
Creating hanlon_server_1
Creating hanlon_tftpd_1
root@ubuntu-hanlon:~/Hanlon# docker ps -a
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                    NAMES
744e89a7eb49        atftpd              "/bin/sh -c /run.sh"     4 seconds ago       Up 2 seconds        0.0.0.0:69->69/udp       hanlon_tftpd_1
0ef0f2314cae        hanlon              "/docker-entrypoint.s"   6 seconds ago       Up 3 seconds        0.0.0.0:8026->8026/tcp   hanlon_server_1
e71fdd455b00        mongo               "/entrypoint.sh mongo"   7 seconds ago       Up 5 seconds        27017/tcp                hanlon_mongo_1
```

Confirming that `docker-compose.yml` and `hanlon.env` are not in the container.
```bash
root@ubuntu-hanlon:~/Hanlon# docker exec -it hanlon_server_1 bash
root@0ef0f2314cae:/home/hanlon# ls -alh
total 124K
drwxr-xr-x 13 root root 4.0K Feb 12 18:58 .
drwxr-xr-x  5 root root 4.0K Feb 12 18:58 ..
-rw-r--r--  1 root root  345 Feb 12 18:37 .autotest
-rw-r--r--  1 root root   30 Feb 12 18:37 .dockerignore
drwxr-xr-x  8 root root 4.0K Feb 12 18:58 .git
-rw-r--r--  1 root root  393 Feb 12 18:37 .gitignore
-rw-r--r--  1 root root  648 Feb 12 18:37 .mailmap
-rw-r--r--  1 root root  528 Feb 12 18:37 .travis.yml
-rw-r--r--  1 root root   38 Feb 12 18:37 .yardopts
-rw-r--r--  1 root root  13K Feb 12 18:37 CONTRIBUTING.md
-rw-r--r--  1 root root 1.8K Feb 12 18:37 Dockerfile
-rw-r--r--  1 root root   37 Feb 12 18:37 Gemfile
-rw-r--r--  1 root root 2.9K Feb 12 18:37 Gemfile.lock
-rw-r--r--  1 root root  760 Feb 12 18:37 LICENSE
-rw-r--r--  1 root root 5.7K Feb 12 18:37 README.md
-rw-r--r--  1 root root 1.8K Feb 12 18:37 Rakefile
drwxr-xr-x  5 root root 4.0K Feb 12 18:58 cli
drwxr-xr-x 12 root root 4.0K Feb 12 18:37 core
-rw-r--r--  1 root root  865 Feb 12 18:37 docker-entrypoint.sh
-rw-r--r--  1 root root 1.9K Feb 12 18:37 hanlon.gemspec
-rwxr-xr-x  1 root root 6.0K Feb 12 18:37 hanlon_init
drwxr-xr-x  2 root root 4.0K Feb 12 15:30 image
drwxr-xr-x  3 root root 4.0K Feb 12 18:37 scripts
drwxr-xr-x  4 root root 4.0K Feb 12 18:37 test
drwxr-xr-x  5 root root 4.0K Feb 12 18:37 util
drwxr-xr-x  7 root root 4.0K Feb 12 18:58 web
```

Confirming TFTP container `hanlon.ipxe`
```
root@ubuntu-hanlon:~/Hanlon# docker exec -it hanlon_tftpd_1 bash
root@c34da89e98fb:/# tail /tftpboot/
hanlon.ipxe          ipxe-debug.lkrn      ipxe-debug.pxe       ipxe.lkrn            ipxe.pxe             menu.c32             pxelinux.0           pxelinux.cfg/        undionly-debug.kpxe  undionly.kpxe
root@c34da89e98fb:/# tail /tftpboot/hanlon.ipxe


:s1

chain http://10.53.252.89:8026/hanlon/api/v1/boot?uuid=${uuid}&mac_id=${net0/mac}_${net1/mac}_${net2/mac}_${net3/mac}_${net4/mac}_${net5/mac}_${net6/mac}_${net7/mac}&dhcp_mac=${dhcp_mac} || goto error


:error
sleep 15
reboot
```