### PR TITLE
Added models for major Ubuntu versions

### DIFF
--- a/core/model/model_dep.rb
+++ b/core/model/model_dep.rb
@@ -34,6 +34,11 @@ require 'model/oraclelinux_6'
 require 'model/ubuntu_oneiric'
 require 'model/ubuntu_precise'
 require 'model/ubuntu_precise_ip_pool'
+require 'model/ubuntu_quantal'
+require 'model/ubuntu_raring'
+require 'model/ubuntu_trusty'
+require 'model/ubuntu_vivid'
+require 'model/ubuntu_xenial'
 
 # level 3 - debian
 require 'model/debian_wheezy'

--- a/core/model/ubuntu/quantal/boot_install.erb
+++ b/core/model/ubuntu/quantal/boot_install.erb
@@ -1,0 +1,10 @@
+#!ipxe
+echo Hanlon <%= @label %> model boot_call
+echo Installation node UUID : <%= node.uuid %>
+echo Installation image UUID: <%= @image_uuid %>
+echo Active Model node state: <%= @current_state %>
+
+sleep 3
+kernel <%= "#{image_svc_uri}/#{@image_uuid}/#{kernel_path} #{kernel_args(policy_uuid)}" %> || goto error
+initrd <%= "#{image_svc_uri}/#{@image_uuid}/#{initrd_path}" %> || goto error
+boot

--- a/core/model/ubuntu/quantal/boot_local.erb
+++ b/core/model/ubuntu/quantal/boot_local.erb
@@ -1,0 +1,9 @@
+#!ipxe
+echo Hanlon <%= @label %> model boot_call
+echo Installation node UUID : <%= node.uuid %>
+echo Installation image UUID: <%= @image_uuid %>
+echo Active Model node state: <%= @current_state %>
+echo Continuing local boot
+
+sleep 3
+sanboot --no-describe --drive 0x80

--- a/core/model/ubuntu/quantal/kernel_args.erb
+++ b/core/model/ubuntu/quantal/kernel_args.erb
@@ -1,0 +1,3 @@
+<% if @node.dhcp_mac %>BOOTIF=<%= @node.dhcp_mac %>  preseed/url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/preseed/file" %> debian-installer/locale=en_US netcfg/choose_interface=auto priority=critical
+<% else %>preseed/url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/preseed/file" %> debian-installer/locale=en_US netcfg/choose_interface=auto priority=critical
+<% end %>

--- a/core/model/ubuntu/quantal/os_boot.erb
+++ b/core/model/ubuntu/quantal/os_boot.erb
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+hostname <%= hostname %>
+echo <%= hostname %> > /etc/hostname
+
+# this set of commands should convert the first local (but non-loopback) IP
+# address in the /etc/hosts file to an entry that has the fully-qualified
+# hostname and local hostname as part of the entry (so that tehse names can
+# be resolved properly).  A backup of the original file will be left in place
+# in the /etc/hosts- file
+cp -p /etc/hosts /etc/hosts-
+grep '^127\.0\.0\.1.*' /etc/hosts- > /etc/hosts
+grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | head -1 | sed 's/^\(127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\)\([[:blank:]]\{1,\}\)\(.*\)$/\1\2'<%= hostname %>.<%= domainname %>'\2'<%= hostname %>'/' >> /etc/hosts
+grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | tail -n +2 >> /etc/hosts
+grep -v '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' /etc/hosts- >> /etc/hosts
+
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "set_hostname_ok") %> || curl <%= callback_url("postinstall", "set_hostname_fail") %>
+
+sed -i 's_<%= config.hanlon_server %>:<%= config.api_port %><%= config.websvc_root %>/image/os/<%= @image_uuid %>_archive.ubuntu.com/ubuntu_g' /etc/apt/sources.list && curl <%= callback_url("postinstall", "sources_fix") %>
+apt-get -y update
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_update_ok") %> || curl <%= callback_url("postinstall", "apt_update_fail") %>
+
+apt-get -y upgrade
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_upgrade_ok") %> || curl <%= callback_url("postinstall", "apt_upgrade_fail") %>
+
+# Get current IP
+default_gw_device=`route | grep default | awk '{print $8}'`
+node_ip=`ifconfig $default_gw_device | grep -w inet | awk -F: '{print $2}' | awk '{print $1}'`
+# Send IP up
+curl <%= callback_url("postinstall", "send_ips") %>/$node_ip
+# get final script
+curl <%= callback_url("postinstall", "boot") %> | sh
+# Send final state
+curl <%= callback_url("postinstall", "final") %> &

--- a/core/model/ubuntu/quantal/os_complete.erb
+++ b/core/model/ubuntu/quantal/os_complete.erb
@@ -1,0 +1,7 @@
+#!/bin/bash
+echo Hanlon policy successfully applied > /tmp/hanlon_complete.log
+echo Model <%= @label %> - <%= @description %> >> /tmp/hanlon_complete.log
+echo Image UUID <%= @image_uuid %> >> /tmp/hanlon_complete.log
+echo Node UUID: <%= @node.uuid %> >> /tmp/hanlon_complete.log
+
+sed -i '/hanlon_postinstall/d' /etc/rc.local

--- a/core/model/ubuntu/quantal/preseed.erb
+++ b/core/model/ubuntu/quantal/preseed.erb
@@ -29,7 +29,7 @@ d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 d-i partman-md/confirm boolean true
-d-i live-installer/net-image string http://<%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
+d-i live-installer/net-image string <%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
 d-i passwd/root-login boolean true
 d-i passwd/make-user boolean true
 d-i passwd/root-password password <%= @root_password %>

--- a/core/model/ubuntu/quantal/preseed.erb
+++ b/core/model/ubuntu/quantal/preseed.erb
@@ -1,0 +1,55 @@
+d-i console-setup/ask_detect boolean false
+d-i keyboard-configuration/layoutcode string us
+d-i netcfg/choose_interface select auto
+d-i netcfg/get_hostname string <%= hostname %>
+d-i netcfg/get_domain string hanlonlab.local
+d-i netcfg/no_default_route boolean true
+d-i mirror/protocol string http
+d-i mirror/country string manual
+d-i mirror/http/hostname string <%= config.hanlon_server %>:<%= config.api_port %>
+d-i mirror/http/directory string <%= config.websvc_root %>/image/os/<%= @image_uuid %>
+d-i mirror/http/proxy string
+d-i clock-setup/utc boolean true
+d-i time/zone string US/Central
+d-i clock-setup/ntp boolean true
+d-i partman-auto/disk string /dev/sda
+d-i partman-auto/method string regular
+d-i partman-auto-lvm/new_vg_name string vg0
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-md/device_remove_md boolean true
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/purge_lvm_from_device boolean true
+d-i partman/default_filesystem string ext4
+d-i partman-auto/init_automatically_partition select biggest_free
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman-md/confirm boolean true
+d-i live-installer/net-image string http://<%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
+d-i passwd/root-login boolean true
+d-i passwd/make-user boolean true
+d-i passwd/root-password password <%= @root_password %>
+d-i passwd/root-password-again password <%= @root_password %>
+d-i passwd/user-fullname string User
+d-i passwd/username string user
+d-i passwd/user-password password insecure
+d-i passwd/user-password-again password insecure
+d-i user-setup/allow-password-weak boolean true
+d-i apt-setup/restricted boolean true
+d-i pkgsel/include string curl openssh-server
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i finish-install/reboot_in_progress note
+#Our callbacks
+d-i preseed/early_command string wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/preseed/start
+d-i preseed/late_command string  \
+wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/preseed/end; \
+wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/postinstall/inject -O /target/usr/local/bin/hanlon_postinstall.sh;  \
+sed -i '/exit 0/d' /target/etc/rc.local;  \
+echo bash /usr/local/bin/hanlon_postinstall.sh >> /target/etc/rc.local; \
+echo exit 0 >> /target/etc/rc.local;  \
+chmod +x /target/usr/local/bin/hanlon_postinstall.sh

--- a/core/model/ubuntu/raring/boot_install.erb
+++ b/core/model/ubuntu/raring/boot_install.erb
@@ -1,0 +1,10 @@
+#!ipxe
+echo Hanlon <%= @label %> model boot_call
+echo Installation node UUID : <%= node.uuid %>
+echo Installation image UUID: <%= @image_uuid %>
+echo Active Model node state: <%= @current_state %>
+
+sleep 3
+kernel <%= "#{image_svc_uri}/#{@image_uuid}/#{kernel_path} #{kernel_args(policy_uuid)}" %> || goto error
+initrd <%= "#{image_svc_uri}/#{@image_uuid}/#{initrd_path}" %> || goto error
+boot

--- a/core/model/ubuntu/raring/boot_local.erb
+++ b/core/model/ubuntu/raring/boot_local.erb
@@ -1,0 +1,9 @@
+#!ipxe
+echo Hanlon <%= @label %> model boot_call
+echo Installation node UUID : <%= node.uuid %>
+echo Installation image UUID: <%= @image_uuid %>
+echo Active Model node state: <%= @current_state %>
+echo Continuing local boot
+
+sleep 3
+sanboot --no-describe --drive 0x80

--- a/core/model/ubuntu/raring/kernel_args.erb
+++ b/core/model/ubuntu/raring/kernel_args.erb
@@ -1,0 +1,3 @@
+<% if @node.dhcp_mac %>BOOTIF=<%= @node.dhcp_mac %>  preseed/url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/preseed/file" %> debian-installer/locale=en_US netcfg/choose_interface=auto priority=critical
+<% else %>preseed/url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/preseed/file" %> debian-installer/locale=en_US netcfg/choose_interface=auto priority=critical
+<% end %>

--- a/core/model/ubuntu/raring/os_boot.erb
+++ b/core/model/ubuntu/raring/os_boot.erb
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+hostname <%= hostname %>
+echo <%= hostname %> > /etc/hostname
+
+# this set of commands should convert the first local (but non-loopback) IP
+# address in the /etc/hosts file to an entry that has the fully-qualified
+# hostname and local hostname as part of the entry (so that tehse names can
+# be resolved properly).  A backup of the original file will be left in place
+# in the /etc/hosts- file
+cp -p /etc/hosts /etc/hosts-
+grep '^127\.0\.0\.1.*' /etc/hosts- > /etc/hosts
+grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | head -1 | sed 's/^\(127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\)\([[:blank:]]\{1,\}\)\(.*\)$/\1\2'<%= hostname %>.<%= domainname %>'\2'<%= hostname %>'/' >> /etc/hosts
+grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | tail -n +2 >> /etc/hosts
+grep -v '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' /etc/hosts- >> /etc/hosts
+
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "set_hostname_ok") %> || curl <%= callback_url("postinstall", "set_hostname_fail") %>
+
+sed -i 's_<%= config.hanlon_server %>:<%= config.api_port %><%= config.websvc_root %>/image/os/<%= @image_uuid %>_archive.ubuntu.com/ubuntu_g' /etc/apt/sources.list && curl <%= callback_url("postinstall", "sources_fix") %>
+apt-get -y update
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_update_ok") %> || curl <%= callback_url("postinstall", "apt_update_fail") %>
+
+apt-get -y upgrade
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_upgrade_ok") %> || curl <%= callback_url("postinstall", "apt_upgrade_fail") %>
+
+# Get current IP
+default_gw_device=`route | grep default | awk '{print $8}'`
+node_ip=`ifconfig $default_gw_device | grep -w inet | awk -F: '{print $2}' | awk '{print $1}'`
+# Send IP up
+curl <%= callback_url("postinstall", "send_ips") %>/$node_ip
+# get final script
+curl <%= callback_url("postinstall", "boot") %> | sh
+# Send final state
+curl <%= callback_url("postinstall", "final") %> &

--- a/core/model/ubuntu/raring/os_complete.erb
+++ b/core/model/ubuntu/raring/os_complete.erb
@@ -1,0 +1,7 @@
+#!/bin/bash
+echo Hanlon policy successfully applied > /tmp/hanlon_complete.log
+echo Model <%= @label %> - <%= @description %> >> /tmp/hanlon_complete.log
+echo Image UUID <%= @image_uuid %> >> /tmp/hanlon_complete.log
+echo Node UUID: <%= @node.uuid %> >> /tmp/hanlon_complete.log
+
+sed -i '/hanlon_postinstall/d' /etc/rc.local

--- a/core/model/ubuntu/raring/preseed.erb
+++ b/core/model/ubuntu/raring/preseed.erb
@@ -29,7 +29,7 @@ d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 d-i partman-md/confirm boolean true
-d-i live-installer/net-image string http://<%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
+d-i live-installer/net-image string <%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
 d-i passwd/root-login boolean true
 d-i passwd/make-user boolean true
 d-i passwd/root-password password <%= @root_password %>

--- a/core/model/ubuntu/raring/preseed.erb
+++ b/core/model/ubuntu/raring/preseed.erb
@@ -1,0 +1,55 @@
+d-i console-setup/ask_detect boolean false
+d-i keyboard-configuration/layoutcode string us
+d-i netcfg/choose_interface select auto
+d-i netcfg/get_hostname string <%= hostname %>
+d-i netcfg/get_domain string hanlonlab.local
+d-i netcfg/no_default_route boolean true
+d-i mirror/protocol string http
+d-i mirror/country string manual
+d-i mirror/http/hostname string <%= config.hanlon_server %>:<%= config.api_port %>
+d-i mirror/http/directory string <%= config.websvc_root %>/image/os/<%= @image_uuid %>
+d-i mirror/http/proxy string
+d-i clock-setup/utc boolean true
+d-i time/zone string US/Central
+d-i clock-setup/ntp boolean true
+d-i partman-auto/disk string /dev/sda
+d-i partman-auto/method string regular
+d-i partman-auto-lvm/new_vg_name string vg0
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-md/device_remove_md boolean true
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/purge_lvm_from_device boolean true
+d-i partman/default_filesystem string ext4
+d-i partman-auto/init_automatically_partition select biggest_free
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman-md/confirm boolean true
+d-i live-installer/net-image string http://<%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
+d-i passwd/root-login boolean true
+d-i passwd/make-user boolean true
+d-i passwd/root-password password <%= @root_password %>
+d-i passwd/root-password-again password <%= @root_password %>
+d-i passwd/user-fullname string User
+d-i passwd/username string user
+d-i passwd/user-password password insecure
+d-i passwd/user-password-again password insecure
+d-i user-setup/allow-password-weak boolean true
+d-i apt-setup/restricted boolean true
+d-i pkgsel/include string curl openssh-server
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i finish-install/reboot_in_progress note
+#Our callbacks
+d-i preseed/early_command string wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/preseed/start
+d-i preseed/late_command string  \
+wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/preseed/end; \
+wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/postinstall/inject -O /target/usr/local/bin/hanlon_postinstall.sh;  \
+sed -i '/exit 0/d' /target/etc/rc.local;  \
+echo bash /usr/local/bin/hanlon_postinstall.sh >> /target/etc/rc.local; \
+echo exit 0 >> /target/etc/rc.local;  \
+chmod +x /target/usr/local/bin/hanlon_postinstall.sh

--- a/core/model/ubuntu/trusty/boot_install.erb
+++ b/core/model/ubuntu/trusty/boot_install.erb
@@ -1,0 +1,10 @@
+#!ipxe
+echo Hanlon <%= @label %> model boot_call
+echo Installation node UUID : <%= node.uuid %>
+echo Installation image UUID: <%= @image_uuid %>
+echo Active Model node state: <%= @current_state %>
+
+sleep 3
+kernel <%= "#{image_svc_uri}/#{@image_uuid}/#{kernel_path} #{kernel_args(policy_uuid)}" %> || goto error
+initrd <%= "#{image_svc_uri}/#{@image_uuid}/#{initrd_path}" %> || goto error
+boot

--- a/core/model/ubuntu/trusty/boot_local.erb
+++ b/core/model/ubuntu/trusty/boot_local.erb
@@ -1,0 +1,9 @@
+#!ipxe
+echo Hanlon <%= @label %> model boot_call
+echo Installation node UUID : <%= node.uuid %>
+echo Installation image UUID: <%= @image_uuid %>
+echo Active Model node state: <%= @current_state %>
+echo Continuing local boot
+
+sleep 3
+sanboot --no-describe --drive 0x80

--- a/core/model/ubuntu/trusty/kernel_args.erb
+++ b/core/model/ubuntu/trusty/kernel_args.erb
@@ -1,0 +1,3 @@
+<% if @node.dhcp_mac %>BOOTIF=<%= @node.dhcp_mac %>  preseed/url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/preseed/file" %> debian-installer/locale=en_US netcfg/choose_interface=auto priority=critical
+<% else %>preseed/url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/preseed/file" %> debian-installer/locale=en_US netcfg/choose_interface=auto priority=critical
+<% end %>

--- a/core/model/ubuntu/trusty/os_boot.erb
+++ b/core/model/ubuntu/trusty/os_boot.erb
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+hostname <%= hostname %>
+echo <%= hostname %> > /etc/hostname
+
+# this set of commands should convert the first local (but non-loopback) IP
+# address in the /etc/hosts file to an entry that has the fully-qualified
+# hostname and local hostname as part of the entry (so that tehse names can
+# be resolved properly).  A backup of the original file will be left in place
+# in the /etc/hosts- file
+cp -p /etc/hosts /etc/hosts-
+grep '^127\.0\.0\.1.*' /etc/hosts- > /etc/hosts
+grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | head -1 | sed 's/^\(127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\)\([[:blank:]]\{1,\}\)\(.*\)$/\1\2'<%= hostname %>.<%= domainname %>'\2'<%= hostname %>'/' >> /etc/hosts
+grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | tail -n +2 >> /etc/hosts
+grep -v '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' /etc/hosts- >> /etc/hosts
+
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "set_hostname_ok") %> || curl <%= callback_url("postinstall", "set_hostname_fail") %>
+
+sed -i 's_<%= config.hanlon_server %>:<%= config.api_port %><%= config.websvc_root %>/image/os/<%= @image_uuid %>_archive.ubuntu.com/ubuntu_g' /etc/apt/sources.list && curl <%= callback_url("postinstall", "sources_fix") %>
+apt-get -y update
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_update_ok") %> || curl <%= callback_url("postinstall", "apt_update_fail") %>
+
+apt-get -y upgrade
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_upgrade_ok") %> || curl <%= callback_url("postinstall", "apt_upgrade_fail") %>
+
+# Get current IP
+default_gw_device=`route | grep default | awk '{print $8}'`
+node_ip=`ifconfig $default_gw_device | grep -w inet | awk -F: '{print $2}' | awk '{print $1}'`
+# Send IP up
+curl <%= callback_url("postinstall", "send_ips") %>/$node_ip
+# get final script
+curl <%= callback_url("postinstall", "boot") %> | sh
+# Send final state
+curl <%= callback_url("postinstall", "final") %> &

--- a/core/model/ubuntu/trusty/os_complete.erb
+++ b/core/model/ubuntu/trusty/os_complete.erb
@@ -1,0 +1,7 @@
+#!/bin/bash
+echo Hanlon policy successfully applied > /tmp/hanlon_complete.log
+echo Model <%= @label %> - <%= @description %> >> /tmp/hanlon_complete.log
+echo Image UUID <%= @image_uuid %> >> /tmp/hanlon_complete.log
+echo Node UUID: <%= @node.uuid %> >> /tmp/hanlon_complete.log
+
+sed -i '/hanlon_postinstall/d' /etc/rc.local

--- a/core/model/ubuntu/trusty/preseed.erb
+++ b/core/model/ubuntu/trusty/preseed.erb
@@ -29,7 +29,7 @@ d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 d-i partman-md/confirm boolean true
-d-i live-installer/net-image string http://<%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
+d-i live-installer/net-image string <%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
 d-i passwd/root-login boolean true
 d-i passwd/make-user boolean true
 d-i passwd/root-password password <%= @root_password %>

--- a/core/model/ubuntu/trusty/preseed.erb
+++ b/core/model/ubuntu/trusty/preseed.erb
@@ -1,0 +1,55 @@
+d-i console-setup/ask_detect boolean false
+d-i keyboard-configuration/layoutcode string us
+d-i netcfg/choose_interface select auto
+d-i netcfg/get_hostname string <%= hostname %>
+d-i netcfg/get_domain string hanlonlab.local
+d-i netcfg/no_default_route boolean true
+d-i mirror/protocol string http
+d-i mirror/country string manual
+d-i mirror/http/hostname string <%= config.hanlon_server %>:<%= config.api_port %>
+d-i mirror/http/directory string <%= config.websvc_root %>/image/os/<%= @image_uuid %>
+d-i mirror/http/proxy string
+d-i clock-setup/utc boolean true
+d-i time/zone string US/Central
+d-i clock-setup/ntp boolean true
+d-i partman-auto/disk string /dev/sda
+d-i partman-auto/method string regular
+d-i partman-auto-lvm/new_vg_name string vg0
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-md/device_remove_md boolean true
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/purge_lvm_from_device boolean true
+d-i partman/default_filesystem string ext4
+d-i partman-auto/init_automatically_partition select biggest_free
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman-md/confirm boolean true
+d-i live-installer/net-image string http://<%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
+d-i passwd/root-login boolean true
+d-i passwd/make-user boolean true
+d-i passwd/root-password password <%= @root_password %>
+d-i passwd/root-password-again password <%= @root_password %>
+d-i passwd/user-fullname string User
+d-i passwd/username string user
+d-i passwd/user-password password insecure
+d-i passwd/user-password-again password insecure
+d-i user-setup/allow-password-weak boolean true
+d-i apt-setup/restricted boolean true
+d-i pkgsel/include string curl openssh-server
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i finish-install/reboot_in_progress note
+#Our callbacks
+d-i preseed/early_command string wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/preseed/start
+d-i preseed/late_command string  \
+wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/preseed/end; \
+wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/postinstall/inject -O /target/usr/local/bin/hanlon_postinstall.sh;  \
+sed -i '/exit 0/d' /target/etc/rc.local;  \
+echo bash /usr/local/bin/hanlon_postinstall.sh >> /target/etc/rc.local; \
+echo exit 0 >> /target/etc/rc.local;  \
+chmod +x /target/usr/local/bin/hanlon_postinstall.sh

--- a/core/model/ubuntu/vivid/boot_install.erb
+++ b/core/model/ubuntu/vivid/boot_install.erb
@@ -1,0 +1,10 @@
+#!ipxe
+echo Hanlon <%= @label %> model boot_call
+echo Installation node UUID : <%= node.uuid %>
+echo Installation image UUID: <%= @image_uuid %>
+echo Active Model node state: <%= @current_state %>
+
+sleep 3
+kernel <%= "#{image_svc_uri}/#{@image_uuid}/#{kernel_path} #{kernel_args(policy_uuid)}" %> || goto error
+initrd <%= "#{image_svc_uri}/#{@image_uuid}/#{initrd_path}" %> || goto error
+boot

--- a/core/model/ubuntu/vivid/boot_local.erb
+++ b/core/model/ubuntu/vivid/boot_local.erb
@@ -1,0 +1,9 @@
+#!ipxe
+echo Hanlon <%= @label %> model boot_call
+echo Installation node UUID : <%= node.uuid %>
+echo Installation image UUID: <%= @image_uuid %>
+echo Active Model node state: <%= @current_state %>
+echo Continuing local boot
+
+sleep 3
+sanboot --no-describe --drive 0x80

--- a/core/model/ubuntu/vivid/kernel_args.erb
+++ b/core/model/ubuntu/vivid/kernel_args.erb
@@ -1,0 +1,3 @@
+<% if @node.dhcp_mac %>BOOTIF=<%= @node.dhcp_mac %>  preseed/url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/preseed/file" %> debian-installer/locale=en_US netcfg/choose_interface=auto priority=critical
+<% else %>preseed/url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/preseed/file" %> debian-installer/locale=en_US netcfg/choose_interface=auto priority=critical
+<% end %>

--- a/core/model/ubuntu/vivid/os_boot.erb
+++ b/core/model/ubuntu/vivid/os_boot.erb
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+hostname <%= hostname %>
+echo <%= hostname %> > /etc/hostname
+
+# this set of commands should convert the first local (but non-loopback) IP
+# address in the /etc/hosts file to an entry that has the fully-qualified
+# hostname and local hostname as part of the entry (so that tehse names can
+# be resolved properly).  A backup of the original file will be left in place
+# in the /etc/hosts- file
+cp -p /etc/hosts /etc/hosts-
+grep '^127\.0\.0\.1.*' /etc/hosts- > /etc/hosts
+grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | head -1 | sed 's/^\(127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\)\([[:blank:]]\{1,\}\)\(.*\)$/\1\2'<%= hostname %>.<%= domainname %>'\2'<%= hostname %>'/' >> /etc/hosts
+grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | tail -n +2 >> /etc/hosts
+grep -v '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' /etc/hosts- >> /etc/hosts
+
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "set_hostname_ok") %> || curl <%= callback_url("postinstall", "set_hostname_fail") %>
+
+sed -i 's_<%= config.hanlon_server %>:<%= config.api_port %><%= config.websvc_root %>/image/os/<%= @image_uuid %>_archive.ubuntu.com/ubuntu_g' /etc/apt/sources.list && curl <%= callback_url("postinstall", "sources_fix") %>
+apt-get -y update
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_update_ok") %> || curl <%= callback_url("postinstall", "apt_update_fail") %>
+
+apt-get -y upgrade
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_upgrade_ok") %> || curl <%= callback_url("postinstall", "apt_upgrade_fail") %>
+
+# Get current IP
+default_gw_device=`route | grep default | awk '{print $8}'`
+node_ip=`ifconfig $default_gw_device | grep -w inet | awk -F: '{print $2}' | awk '{print $1}'`
+# Send IP up
+curl <%= callback_url("postinstall", "send_ips") %>/$node_ip
+# get final script
+curl <%= callback_url("postinstall", "boot") %> | sh
+# Send final state
+curl <%= callback_url("postinstall", "final") %> &

--- a/core/model/ubuntu/vivid/os_complete.erb
+++ b/core/model/ubuntu/vivid/os_complete.erb
@@ -1,0 +1,7 @@
+#!/bin/bash
+echo Hanlon policy successfully applied > /tmp/hanlon_complete.log
+echo Model <%= @label %> - <%= @description %> >> /tmp/hanlon_complete.log
+echo Image UUID <%= @image_uuid %> >> /tmp/hanlon_complete.log
+echo Node UUID: <%= @node.uuid %> >> /tmp/hanlon_complete.log
+
+sed -i '/hanlon_postinstall/d' /etc/rc.local

--- a/core/model/ubuntu/vivid/preseed.erb
+++ b/core/model/ubuntu/vivid/preseed.erb
@@ -29,7 +29,7 @@ d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 d-i partman-md/confirm boolean true
-d-i live-installer/net-image string http://<%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
+d-i live-installer/net-image string <%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
 d-i passwd/root-login boolean true
 d-i passwd/make-user boolean true
 d-i passwd/root-password password <%= @root_password %>

--- a/core/model/ubuntu/vivid/preseed.erb
+++ b/core/model/ubuntu/vivid/preseed.erb
@@ -1,0 +1,55 @@
+d-i console-setup/ask_detect boolean false
+d-i keyboard-configuration/layoutcode string us
+d-i netcfg/choose_interface select auto
+d-i netcfg/get_hostname string <%= hostname %>
+d-i netcfg/get_domain string hanlonlab.local
+d-i netcfg/no_default_route boolean true
+d-i mirror/protocol string http
+d-i mirror/country string manual
+d-i mirror/http/hostname string <%= config.hanlon_server %>:<%= config.api_port %>
+d-i mirror/http/directory string <%= config.websvc_root %>/image/os/<%= @image_uuid %>
+d-i mirror/http/proxy string
+d-i clock-setup/utc boolean true
+d-i time/zone string US/Central
+d-i clock-setup/ntp boolean true
+d-i partman-auto/disk string /dev/sda
+d-i partman-auto/method string regular
+d-i partman-auto-lvm/new_vg_name string vg0
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-md/device_remove_md boolean true
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/purge_lvm_from_device boolean true
+d-i partman/default_filesystem string ext4
+d-i partman-auto/init_automatically_partition select biggest_free
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman-md/confirm boolean true
+d-i live-installer/net-image string http://<%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
+d-i passwd/root-login boolean true
+d-i passwd/make-user boolean true
+d-i passwd/root-password password <%= @root_password %>
+d-i passwd/root-password-again password <%= @root_password %>
+d-i passwd/user-fullname string User
+d-i passwd/username string user
+d-i passwd/user-password password insecure
+d-i passwd/user-password-again password insecure
+d-i user-setup/allow-password-weak boolean true
+d-i apt-setup/restricted boolean true
+d-i pkgsel/include string curl openssh-server
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i finish-install/reboot_in_progress note
+#Our callbacks
+d-i preseed/early_command string wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/preseed/start
+d-i preseed/late_command string  \
+wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/preseed/end; \
+wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/postinstall/inject -O /target/usr/local/bin/hanlon_postinstall.sh;  \
+sed -i '/exit 0/d' /target/etc/rc.local;  \
+echo bash /usr/local/bin/hanlon_postinstall.sh >> /target/etc/rc.local; \
+echo exit 0 >> /target/etc/rc.local;  \
+chmod +x /target/usr/local/bin/hanlon_postinstall.sh

--- a/core/model/ubuntu/xenial/boot_install.erb
+++ b/core/model/ubuntu/xenial/boot_install.erb
@@ -1,0 +1,10 @@
+#!ipxe
+echo Hanlon <%= @label %> model boot_call
+echo Installation node UUID : <%= node.uuid %>
+echo Installation image UUID: <%= @image_uuid %>
+echo Active Model node state: <%= @current_state %>
+
+sleep 3
+kernel <%= "#{image_svc_uri}/#{@image_uuid}/#{kernel_path} #{kernel_args(policy_uuid)}" %> || goto error
+initrd <%= "#{image_svc_uri}/#{@image_uuid}/#{initrd_path}" %> || goto error
+boot

--- a/core/model/ubuntu/xenial/boot_local.erb
+++ b/core/model/ubuntu/xenial/boot_local.erb
@@ -1,0 +1,9 @@
+#!ipxe
+echo Hanlon <%= @label %> model boot_call
+echo Installation node UUID : <%= node.uuid %>
+echo Installation image UUID: <%= @image_uuid %>
+echo Active Model node state: <%= @current_state %>
+echo Continuing local boot
+
+sleep 3
+sanboot --no-describe --drive 0x80

--- a/core/model/ubuntu/xenial/kernel_args.erb
+++ b/core/model/ubuntu/xenial/kernel_args.erb
@@ -1,0 +1,3 @@
+<% if @node.dhcp_mac %>BOOTIF=<%= @node.dhcp_mac %>  preseed/url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/preseed/file" %> debian-installer/locale=en_US netcfg/choose_interface=auto priority=critical
+<% else %>preseed/url=<%= "#{api_svc_uri}/policy/callback/#{policy_uuid}/preseed/file" %> debian-installer/locale=en_US netcfg/choose_interface=auto priority=critical
+<% end %>

--- a/core/model/ubuntu/xenial/os_boot.erb
+++ b/core/model/ubuntu/xenial/os_boot.erb
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+hostname <%= hostname %>
+echo <%= hostname %> > /etc/hostname
+
+# this set of commands should convert the first local (but non-loopback) IP
+# address in the /etc/hosts file to an entry that has the fully-qualified
+# hostname and local hostname as part of the entry (so that tehse names can
+# be resolved properly).  A backup of the original file will be left in place
+# in the /etc/hosts- file
+cp -p /etc/hosts /etc/hosts-
+grep '^127\.0\.0\.1.*' /etc/hosts- > /etc/hosts
+grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | head -1 | sed 's/^\(127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\)\([[:blank:]]\{1,\}\)\(.*\)$/\1\2'<%= hostname %>.<%= domainname %>'\2'<%= hostname %>'/' >> /etc/hosts
+grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | tail -n +2 >> /etc/hosts
+grep -v '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' /etc/hosts- >> /etc/hosts
+
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "set_hostname_ok") %> || curl <%= callback_url("postinstall", "set_hostname_fail") %>
+
+sed -i 's_<%= config.hanlon_server %>:<%= config.api_port %><%= config.websvc_root %>/image/os/<%= @image_uuid %>_archive.ubuntu.com/ubuntu_g' /etc/apt/sources.list && curl <%= callback_url("postinstall", "sources_fix") %>
+apt-get -y update
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_update_ok") %> || curl <%= callback_url("postinstall", "apt_update_fail") %>
+
+apt-get -y upgrade
+[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_upgrade_ok") %> || curl <%= callback_url("postinstall", "apt_upgrade_fail") %>
+
+# Get current IP
+default_gw_device=`route | grep default | awk '{print $8}'`
+node_ip=`ifconfig $default_gw_device | grep -w inet | awk -F: '{print $2}' | awk '{print $1}'`
+# Send IP up
+curl <%= callback_url("postinstall", "send_ips") %>/$node_ip
+# get final script
+curl <%= callback_url("postinstall", "boot") %> | sh
+# Send final state
+curl <%= callback_url("postinstall", "final") %> &

--- a/core/model/ubuntu/xenial/os_complete.erb
+++ b/core/model/ubuntu/xenial/os_complete.erb
@@ -1,0 +1,7 @@
+#!/bin/bash
+echo Hanlon policy successfully applied > /tmp/hanlon_complete.log
+echo Model <%= @label %> - <%= @description %> >> /tmp/hanlon_complete.log
+echo Image UUID <%= @image_uuid %> >> /tmp/hanlon_complete.log
+echo Node UUID: <%= @node.uuid %> >> /tmp/hanlon_complete.log
+
+sed -i '/hanlon_postinstall/d' /etc/rc.local

--- a/core/model/ubuntu/xenial/preseed.erb
+++ b/core/model/ubuntu/xenial/preseed.erb
@@ -29,7 +29,7 @@ d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 d-i partman-md/confirm boolean true
-d-i live-installer/net-image string http://<%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
+d-i live-installer/net-image string <%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
 d-i passwd/root-login boolean true
 d-i passwd/make-user boolean true
 d-i passwd/root-password password <%= @root_password %>

--- a/core/model/ubuntu/xenial/preseed.erb
+++ b/core/model/ubuntu/xenial/preseed.erb
@@ -1,0 +1,55 @@
+d-i console-setup/ask_detect boolean false
+d-i keyboard-configuration/layoutcode string us
+d-i netcfg/choose_interface select auto
+d-i netcfg/get_hostname string <%= hostname %>
+d-i netcfg/get_domain string hanlonlab.local
+d-i netcfg/no_default_route boolean true
+d-i mirror/protocol string http
+d-i mirror/country string manual
+d-i mirror/http/hostname string <%= config.hanlon_server %>:<%= config.api_port %>
+d-i mirror/http/directory string <%= config.websvc_root %>/image/os/<%= @image_uuid %>
+d-i mirror/http/proxy string
+d-i clock-setup/utc boolean true
+d-i time/zone string US/Central
+d-i clock-setup/ntp boolean true
+d-i partman-auto/disk string /dev/sda
+d-i partman-auto/method string regular
+d-i partman-auto-lvm/new_vg_name string vg0
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-md/device_remove_md boolean true
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/purge_lvm_from_device boolean true
+d-i partman/default_filesystem string ext4
+d-i partman-auto/init_automatically_partition select biggest_free
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman-md/confirm boolean true
+d-i live-installer/net-image string http://<%= config.hanlon_uri %>/<%= config.websvc_root %>/image/os/<%= @image_uuid %>/install/filesystem.squashfs
+d-i passwd/root-login boolean true
+d-i passwd/make-user boolean true
+d-i passwd/root-password password <%= @root_password %>
+d-i passwd/root-password-again password <%= @root_password %>
+d-i passwd/user-fullname string User
+d-i passwd/username string user
+d-i passwd/user-password password insecure
+d-i passwd/user-password-again password insecure
+d-i user-setup/allow-password-weak boolean true
+d-i apt-setup/restricted boolean true
+d-i pkgsel/include string curl openssh-server
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i finish-install/reboot_in_progress note
+#Our callbacks
+d-i preseed/early_command string wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/preseed/start
+d-i preseed/late_command string  \
+wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/preseed/end; \
+wget <%= api_svc_uri %>/policy/callback/<%= policy_uuid %>/postinstall/inject -O /target/usr/local/bin/hanlon_postinstall.sh;  \
+sed -i '/exit 0/d' /target/etc/rc.local;  \
+echo bash /usr/local/bin/hanlon_postinstall.sh >> /target/etc/rc.local; \
+echo exit 0 >> /target/etc/rc.local;  \
+chmod +x /target/usr/local/bin/hanlon_postinstall.sh

--- a/core/model/ubuntu_oneiric.rb
+++ b/core/model/ubuntu_oneiric.rb
@@ -16,7 +16,7 @@ module ProjectHanlon
         # Static config
         @hidden = false
         @name = "ubuntu_oneiric"
-        @description = "Ubuntu Oneiric Model"
+        @description = "Ubuntu Oneiric (11.10) Model"
         # Metadata vars
         @hostname_prefix = nil
         # State / must have a starting state

--- a/core/model/ubuntu_precise.rb
+++ b/core/model/ubuntu_precise.rb
@@ -13,7 +13,7 @@ module ProjectHanlon
         # Static config
         @hidden = false
         @name = "ubuntu_precise"
-        @description = "Ubuntu Precise Model"
+        @description = "Ubuntu Precise (12.04) Model"
         # Metadata vars
         @hostname_prefix = nil
         # State / must have a starting state

--- a/core/model/ubuntu_precise_ip_pool.rb
+++ b/core/model/ubuntu_precise_ip_pool.rb
@@ -13,7 +13,7 @@ module ProjectHanlon
         # Static config
         @hidden          = false
         @name            = "ubuntu_precise_ip_pool"
-        @description     = "Ubuntu Precise Model (IP Pool)"
+        @description     = "Ubuntu Precise (12.04) Model (IP Pool)"
         # Metadata vars
         @hostname_prefix = nil
         # State / must have a starting state

--- a/core/model/ubuntu_quantal.rb
+++ b/core/model/ubuntu_quantal.rb
@@ -1,0 +1,34 @@
+require "erb"
+
+# Root ProjectHanlon namespace
+module ProjectHanlon
+  module ModelTemplate
+    # Root Model object
+    # @abstract
+    class UbuntuQuantal < Ubuntu
+      include(ProjectHanlon::Logging)
+
+      def initialize(hash)
+        super(hash)
+        # Static config
+        @hidden = false
+        @name = "ubuntu_quantal"
+        @description = "Ubuntu Quantal (12.10) Model"
+        # Metadata vars
+        @hostname_prefix = nil
+        # State / must have a starting state
+        @current_state = :init
+        # Image UUID
+        @image_uuid = true
+        # Image prefix we can attach
+        @image_prefix = "os"
+        # Enable agent brokers for this model
+        @broker_plugin = :agent
+        @osversion = 'quantal'
+        @final_state = :os_complete
+        from_hash(hash) unless hash == nil
+      end
+
+    end
+  end
+end

--- a/core/model/ubuntu_raring.rb
+++ b/core/model/ubuntu_raring.rb
@@ -1,0 +1,34 @@
+require "erb"
+
+# Root ProjectHanlon namespace
+module ProjectHanlon
+  module ModelTemplate
+    # Root Model object
+    # @abstract
+    class UbuntuRaring < Ubuntu
+      include(ProjectHanlon::Logging)
+
+      def initialize(hash)
+        super(hash)
+        # Static config
+        @hidden = false
+        @name = "ubuntu_raring"
+        @description = "Ubuntu Raring (13.04) Model"
+        # Metadata vars
+        @hostname_prefix = nil
+        # State / must have a starting state
+        @current_state = :init
+        # Image UUID
+        @image_uuid = true
+        # Image prefix we can attach
+        @image_prefix = "os"
+        # Enable agent brokers for this model
+        @broker_plugin = :agent
+        @osversion = 'raring'
+        @final_state = :os_complete
+        from_hash(hash) unless hash == nil
+      end
+
+    end
+  end
+end

--- a/core/model/ubuntu_trusty.rb
+++ b/core/model/ubuntu_trusty.rb
@@ -1,0 +1,34 @@
+require "erb"
+
+# Root ProjectHanlon namespace
+module ProjectHanlon
+  module ModelTemplate
+    # Root Model object
+    # @abstract
+    class UbuntuTrusty < Ubuntu
+      include(ProjectHanlon::Logging)
+
+      def initialize(hash)
+        super(hash)
+        # Static config
+        @hidden = false
+        @name = "ubuntu_trusty"
+        @description = "Ubuntu Trusty (14.04) Model"
+        # Metadata vars
+        @hostname_prefix = nil
+        # State / must have a starting state
+        @current_state = :init
+        # Image UUID
+        @image_uuid = true
+        # Image prefix we can attach
+        @image_prefix = "os"
+        # Enable agent brokers for this model
+        @broker_plugin = :agent
+        @osversion = 'trusty'
+        @final_state = :os_complete
+        from_hash(hash) unless hash == nil
+      end
+
+    end
+  end
+end

--- a/core/model/ubuntu_vivid.rb
+++ b/core/model/ubuntu_vivid.rb
@@ -1,0 +1,34 @@
+require "erb"
+
+# Root ProjectHanlon namespace
+module ProjectHanlon
+  module ModelTemplate
+    # Root Model object
+    # @abstract
+    class UbuntuVivid < Ubuntu
+      include(ProjectHanlon::Logging)
+
+      def initialize(hash)
+        super(hash)
+        # Static config
+        @hidden = false
+        @name = "ubuntu_vivid"
+        @description = "Ubuntu Vivid (15.04) Model"
+        # Metadata vars
+        @hostname_prefix = nil
+        # State / must have a starting state
+        @current_state = :init
+        # Image UUID
+        @image_uuid = true
+        # Image prefix we can attach
+        @image_prefix = "os"
+        # Enable agent brokers for this model
+        @broker_plugin = :agent
+        @osversion = 'vivid'
+        @final_state = :os_complete
+        from_hash(hash) unless hash == nil
+      end
+
+    end
+  end
+end

--- a/core/model/ubuntu_xenial.rb
+++ b/core/model/ubuntu_xenial.rb
@@ -1,0 +1,34 @@
+require "erb"
+
+# Root ProjectHanlon namespace
+module ProjectHanlon
+  module ModelTemplate
+    # Root Model object
+    # @abstract
+    class UbuntuXenial < Ubuntu
+      include(ProjectHanlon::Logging)
+
+      def initialize(hash)
+        super(hash)
+        # Static config
+        @hidden = false
+        @name = "ubuntu_Xenial"
+        @description = "Ubuntu Xenial (16.04) Model"
+        # Metadata vars
+        @hostname_prefix = nil
+        # State / must have a starting state
+        @current_state = :init
+        # Image UUID
+        @image_uuid = true
+        # Image prefix we can attach
+        @image_prefix = "os"
+        # Enable agent brokers for this model
+        @broker_plugin = :agent
+        @osversion = 'xenial'
+        @final_state = :os_complete
+        from_hash(hash) unless hash == nil
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Here are the files to create the models for newer Ubuntu versions. 

Starting with Ubuntu 12.10 (Quantal), the net boot process changed a bit. This added a line to the preseed file to pull in an image of the base filesystem and this process has continued through all the current versions. It is expected to remain the same the 16.04 (Xenial) when it is released. 

I have included models for all major versions (13.04, 14.04, 15.04, 16.04) and 12.10 (since this is the version that changes how net booting worked).