### PR TITLE
Salt Broker

### DIFF
--- a/core/broker/broker_dep.rb
+++ b/core/broker/broker_dep.rb
@@ -9,4 +9,5 @@ require 'broker/base'
 # level 2
 require 'broker/chef'
 require 'broker/puppet'
+require 'broker/salt'
 require 'broker/script'

--- a/core/broker/salt.rb
+++ b/core/broker/salt.rb
@@ -1,0 +1,146 @@
+# The salt plugin which installs salt and hands off to a salt master
+
+# TODO - Make broker properties open rather than rigid
+require "erb"
+require "net/ssh"
+
+# Root namespace for ProjectHanlon
+module ProjectHanlon::BrokerPlugin
+
+  # Root namespace for Salt Broker plugin defined in ProjectHanlon for node handoff
+  class Salt < ProjectHanlon::BrokerPlugin::Base
+    include(ProjectHanlon::Logging)
+
+    def initialize(hash)
+      super(hash)
+
+      @plugin = :salt
+      @description = "SaltStack Salt Master"
+      @hidden = false
+      from_hash(hash) if hash
+      # backwards compat with old @servers array
+      if !@server && defined?(@servers) && !@servers.empty?
+        @server = @servers.first
+      end
+      @req_metadata_hash = {
+        "@server" => {
+          :default      => "",
+          :example      => "salt.example.com",
+          :validation   => '(^$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$)',
+          :required     => false,
+          :description  => "Hostname of Salt Master; optional"
+        },
+        "@broker_version" => {
+          :default      => "stable",
+          :example      => "stable [VERSION], daily, testing, git [TAG/BRANCH/COMMIT_ID]",
+          :validation   => '(^$|^stable(?:\s+[\d\.]+)?$|^daily$|^testing$|^git(?:\s+\w+)?$)',
+          :required     => false,
+          :description  => "Salt Version; blank for stable"
+        },
+        "@environment" => {
+          :default     => "",
+          :example     => "prod",
+          :validation  => '(^.*$)',
+          :required    => false,
+          :description => "Salt environment that the minion targets"
+        }
+      }
+    end
+    
+    def print_item_header
+      if @is_template
+        return "Plugin", "Description"
+      else
+        return "Name", "Description", "Plugin", "UUID", "Server", "Broker Version"
+      end
+    end
+
+    def print_item
+      if @is_template
+        return @plugin.to_s, @description.to_s
+      else
+        return @name, @user_description, @plugin.to_s, @uuid, @server, @broker_version
+      end
+    end
+
+    def agent_hand_off(options = {})
+      @options = options
+      @options[:server] = @server
+      @options[:version] = @broker_version
+      @options[:environment] = @environment
+      @options[:salt_id] ||= @options[:uuid].base62_decode.to_s(16)
+      return false unless validate_options(@options, [:username, :password, :server, :environment, :salt_id, :ipaddress])
+      @salt_script = compile_template
+      logger.debug("salt_script = #{@salt_script}")
+      logger.debug("options = #{options.inspect}")
+      init_minion(options)
+    end
+
+    def proxy_hand_off(options = {})
+      # This seems to only be used by ESXi. Not sure salt will run under ESXi.
+      # For now until there is a need, commenting out. 
+      #
+      # res = "
+      # @@vc_host { '#{options[:ipaddress]}':
+      #   ensure   => 'present',
+      #   username => '#{options[:username]}',
+      #   password => '#{options[:password]}',
+      #   tag      => '#{options[:vcenter_name]}',
+      # }
+      # "
+      # system("puppet apply --certname=#{options[:hostname]} --report -e \"#{res}\"")
+      # :broker_success
+    end
+
+    # Method call for validating that a Broker instance successfully received the node
+    def validate_hand_off(options = {})
+      # Return true until we add validation
+      true
+    end
+
+    def init_minion(options={})
+      @run_script_str = ""
+      begin
+        Net::SSH.start(options[:ipaddress], options[:username], { :password => options[:password], :user_known_hosts_file => '/dev/null'} ) do |session|
+          logger.debug "Copy: #{session.exec! "echo \"#{@salt_script}\" > /root/salt_init.sh" }"
+          logger.debug "Chmod: #{session.exec! "chmod +x /root/salt_init.sh"}"
+          @run_script_str << session.exec!("bash /root/salt_init.sh 2>&1 | tee /root/salt_init.out")
+          @run_script_str.split("\n").each do |line|
+            logger.debug "salt script: #{line}"
+          end
+        end
+      rescue => e
+        logger.error "salt minion error: #{e}"
+        return :broker_fail
+      end
+      # set return to fail by default
+      ret = :broker_fail
+      # set to wait
+      ret = :broker_wait if @run_script_str.include?("has the minion key been accepted")
+      # set to success (this meant autosign was likely on)
+      ret = :broker_success if @run_script_str.include?("Salt installation finished")
+      ret
+    end
+
+
+    def compile_template
+      logger.debug "Compiling template"
+      install_script = File.join(File.dirname(__FILE__), "salt/minion_install.erb")
+      contents = ERB.new(File.read(install_script)).result(binding)
+      logger.debug("Compiled installation script:")
+      logger.error install_script
+      contents.split("\n").each {|x| logger.error x}
+      contents
+    end
+
+    def validate_options(options, req_list)
+      missing_opts = req_list.select do |opt|
+        options[opt] == nil
+      end
+      unless missing_opts.empty?
+        false
+      end
+      true
+    end
+  end
+end

--- a/core/broker/salt/minion_install.erb
+++ b/core/broker/salt/minion_install.erb
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -u
+set -e
+
+function install_salt() {
+    # try curl first
+    curl -L https://bootstrap.saltstack.com -o /tmp/install_salt.sh
+    
+    # if not downloaded, try wget
+    if [[ ! -r /tmp/install_salt.sh ]]; then
+        wget -O /tmp/install_salt.sh https://bootstrap.saltstack.com
+    fi
+
+    # if still not there then give up and complain
+    if [[ ! -r /tmp/install_salt.sh ]]; then
+        echo "**** Salt could not be installed. Both curl and wget do not seem to be installed. ****"
+        exit 1
+    else
+        version='<%= @options[:version] || 'stable' %>'
+        echo \"* Installing salt version: \${version}\"
+        sh /tmp/install_salt.sh -c /tmp -X -P \${version}
+    fi
+}
+
+function configure_salt() {
+    mkdir -p /etc/salt/{minion.d,grains.d}
+    cat >/etc/salt/minion.d/client.conf <<EOFSALTCONF
+<%= "master: #{@options[:server]}" if @options[:server] && !@options[:server].empty? %>
+<%= "environment: #{@options[:environment]}" if @options[:environment] && !@options[:environment].empty? %>
+EOFSALTCONF
+}
+
+function run_minion() {
+    # Now the salt-minion service can be started
+    if [[ -x /etc/init.d/salt-minion ]]; then
+        /etc/init.d/salt-minion start
+    else 
+        systemctl start salt-minion
+    fi
+}
+
+
+function test_connection() {
+    /usr/bin/salt-call grains.items
+}
+
+function highstate() {
+    /usr/bin/salt-call state.highstate
+}
+
+
+function salt_grains() {
+    <% if @options[:metadata] %>
+        echo Installing custom grains
+        <% @options[:metadata].each do |grain,value| %>
+            <% if value && !value.empty? %>
+                echo '<%= grain %>: <%= value %>' >> /etc/salt/grains
+            <% end %>
+        <% end %>
+    <% end %>
+}
+
+
+function provision_salt() {
+    install_salt
+    configure_salt
+    <%= 'salt_grains' if @options[:metadata] %>
+    run_minion
+    
+    # wait a few seconds for the key to be accepted
+    sleep 15
+    test_connection
+    
+    <%= 'highstate' if @options[:highstate] %>
+    
+    echo Salt installation finished!
+    exit 0
+}
+
+provision_salt

--- a/core/model/ubuntu/oneiric/os_boot.erb
+++ b/core/model/ubuntu/oneiric/os_boot.erb
@@ -1,7 +1,31 @@
 #!/bin/bash
 
+cat <<EOF >/root/os_boot.log
+Postinstall os_boot script log
+==============================
+Hanlon settings:
+    Model <%= @label %> - <%= @description %>
+    Image UUID <%= @image_uuid %>
+    Node UUID: <%= @node.uuid %>
+    Script: $0
+=============================
+
+EOF
+
+function send_status() {
+  status=$?
+  step=$1
+
+  [ "$status" -eq 0 ] && curl <%= callback_url("postinstall", "${step}_ok") %> || curl <%= callback_url("postinstall", "${step}_fail") %>
+}
+
+exec >> /root/os_boot.log
+exec 2>&1
+set -x
+
 hostname <%= hostname %>
 echo <%= hostname %> > /etc/hostname
+sleep 15
 
 # this set of commands should convert the first local (but non-loopback) IP
 # address in the /etc/hosts file to an entry that has the fully-qualified
@@ -14,21 +38,28 @@ grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.
 grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | tail -n +2 >> /etc/hosts
 grep -v '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' /etc/hosts- >> /etc/hosts
 
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "set_hostname_ok") %> || curl <%= callback_url("postinstall", "set_hostname_fail") %>
+send_status "set_hostname"
 
 sed -i 's_<%= config.hanlon_server %>:<%= config.api_port %><%= config.websvc_root %>/image/os/<%= @image_uuid %>_archive.ubuntu.com/ubuntu_g' /etc/apt/sources.list && curl <%= callback_url("postinstall", "sources_fix") %>
 apt-get -y update
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_update_ok") %> || curl <%= callback_url("postinstall", "apt_update_fail") %>
+send_status "apt_update"
 
 apt-get -y upgrade
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_upgrade_ok") %> || curl <%= callback_url("postinstall", "apt_upgrade_fail") %>
+send_status "apt_upgrade"
+
+sed -i 's/^#\?\s*PermitRootLogin .*$/PermitRootLogin yes/' /etc/ssh/sshd_config && systemctl restart ssh
+send_status "ssh_root_access"
 
 # Get current IP
 default_gw_device=`route | grep default | awk '{print $8}'`
 node_ip=`ifconfig $default_gw_device | grep -w inet | awk -F: '{print $2}' | awk '{print $1}'`
+
 # Send IP up
 curl <%= callback_url("postinstall", "send_ips") %>/$node_ip
+
 # get final script
 curl <%= callback_url("postinstall", "boot") %> | sh
+send_status "final_script"
+
 # Send final state
 curl <%= callback_url("postinstall", "final") %> &

--- a/core/model/ubuntu/oneiric/os_complete.erb
+++ b/core/model/ubuntu/oneiric/os_complete.erb
@@ -1,7 +1,21 @@
 #!/bin/bash
+<<<<<<< 545b7d740b5f3f243f684229c9497d0480319653
 echo "Hanlon policy successfully applied" > /tmp/hanlon_complete.log
 echo "Model <%= @label %> - <%= @description %>" >> /tmp/hanlon_complete.log
 echo "Image UUID <%= @image_uuid %>" >> /tmp/hanlon_complete.log
 echo "Node UUID: <%= @node.uuid %>" >> /tmp/hanlon_complete.log
+||||||| merged common ancestors
+echo Hanlon policy successfully applied > /tmp/hanlon_complete.log
+echo Model <%= @label %> - <%= @description %> >> /tmp/hanlon_complete.log
+echo Image UUID <%= @image_uuid %> >> /tmp/hanlon_complete.log
+echo Node UUID: <%= @node.uuid %> >> /tmp/hanlon_complete.log
+=======
+log="/root/hanlon_complete.log"
+
+echo "Hanlon policy successfully applied" > $log
+echo "Model <%= @label %> - <%= @description %>" >> $log
+echo "Image UUID <%= @image_uuid %>" >> $log
+echo "Node UUID: <%= @node.uuid %>" >> $log
+>>>>>>> Created salt broker plugin
 
 sed -i '/hanlon_postinstall/d' /etc/rc.local

--- a/core/model/ubuntu/precise/os_boot.erb
+++ b/core/model/ubuntu/precise/os_boot.erb
@@ -1,7 +1,31 @@
 #!/bin/bash
 
+cat <<EOF >/root/os_boot.log
+Postinstall os_boot script log
+==============================
+Hanlon settings:
+    Model <%= @label %> - <%= @description %>
+    Image UUID <%= @image_uuid %>
+    Node UUID: <%= @node.uuid %>
+    Script: $0
+=============================
+
+EOF
+
+function send_status() {
+  status=$?
+  step=$1
+
+  [ "$status" -eq 0 ] && curl <%= callback_url("postinstall", "${step}_ok") %> || curl <%= callback_url("postinstall", "${step}_fail") %>
+}
+
+exec >> /root/os_boot.log
+exec 2>&1
+set -x
+
 hostname <%= hostname %>
 echo <%= hostname %> > /etc/hostname
+sleep 15
 
 # this set of commands should convert the first local (but non-loopback) IP
 # address in the /etc/hosts file to an entry that has the fully-qualified
@@ -14,21 +38,28 @@ grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.
 grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | tail -n +2 >> /etc/hosts
 grep -v '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' /etc/hosts- >> /etc/hosts
 
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "set_hostname_ok") %> || curl <%= callback_url("postinstall", "set_hostname_fail") %>
+send_status "set_hostname"
 
 sed -i 's_<%= config.hanlon_server %>:<%= config.api_port %><%= config.websvc_root %>/image/os/<%= @image_uuid %>_archive.ubuntu.com/ubuntu_g' /etc/apt/sources.list && curl <%= callback_url("postinstall", "sources_fix") %>
 apt-get -y update
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_update_ok") %> || curl <%= callback_url("postinstall", "apt_update_fail") %>
+send_status "apt_update"
 
 apt-get -y upgrade
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_upgrade_ok") %> || curl <%= callback_url("postinstall", "apt_upgrade_fail") %>
+send_status "apt_upgrade"
+
+sed -i 's/^#\?\s*PermitRootLogin .*$/PermitRootLogin yes/' /etc/ssh/sshd_config && systemctl restart ssh
+send_status "ssh_root_access"
 
 # Get current IP
 default_gw_device=`route | grep default | awk '{print $8}'`
 node_ip=`ifconfig $default_gw_device | grep -w inet | awk -F: '{print $2}' | awk '{print $1}'`
+
 # Send IP up
 curl <%= callback_url("postinstall", "send_ips") %>/$node_ip
+
 # get final script
 curl <%= callback_url("postinstall", "boot") %> | sh
+send_status "final_script"
+
 # Send final state
 curl <%= callback_url("postinstall", "final") %> &

--- a/core/model/ubuntu/precise/os_complete.erb
+++ b/core/model/ubuntu/precise/os_complete.erb
@@ -1,7 +1,21 @@
 #!/bin/bash
+<<<<<<< 545b7d740b5f3f243f684229c9497d0480319653
 echo "Hanlon policy successfully applied" > /tmp/hanlon_complete.log
 echo "Model <%= @label %> - <%= @description %>" >> /tmp/hanlon_complete.log
 echo "Image UUID <%= @image_uuid %>" >> /tmp/hanlon_complete.log
 echo "Node UUID: <%= @node.uuid %>" >> /tmp/hanlon_complete.log
+||||||| merged common ancestors
+echo Hanlon policy successfully applied > /tmp/hanlon_complete.log
+echo Model <%= @label %> - <%= @description %> >> /tmp/hanlon_complete.log
+echo Image UUID <%= @image_uuid %> >> /tmp/hanlon_complete.log
+echo Node UUID: <%= @node.uuid %> >> /tmp/hanlon_complete.log
+=======
+log="/root/hanlon_complete.log"
+
+echo "Hanlon policy successfully applied" > $log
+echo "Model <%= @label %> - <%= @description %>" >> $log
+echo "Image UUID <%= @image_uuid %>" >> $log
+echo "Node UUID: <%= @node.uuid %>" >> $log
+>>>>>>> Created salt broker plugin
 
 sed -i '/hanlon_postinstall/d' /etc/rc.local

--- a/core/model/ubuntu/precise_ip_pool/os_boot.erb
+++ b/core/model/ubuntu/precise_ip_pool/os_boot.erb
@@ -1,7 +1,31 @@
 #!/bin/bash
 
+cat <<EOF >/root/os_boot.log
+Postinstall os_boot script log
+==============================
+Hanlon settings:
+    Model <%= @label %> - <%= @description %>
+    Image UUID <%= @image_uuid %>
+    Node UUID: <%= @node.uuid %>
+    Script: $0
+=============================
+
+EOF
+
+function send_status() {
+  status=$?
+  step=$1
+
+  [ "$status" -eq 0 ] && curl <%= callback_url("postinstall", "${step}_ok") %> || curl <%= callback_url("postinstall", "${step}_fail") %>
+}
+
+exec >> /root/os_boot.log
+exec 2>&1
+set -x
+
 hostname <%= hostname %>
 echo <%= hostname %> > /etc/hostname
+sleep 15
 
 # this set of commands should convert the first local (but non-loopback) IP
 # address in the /etc/hosts file to an entry that has the fully-qualified
@@ -14,34 +38,28 @@ grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.
 grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | tail -n +2 >> /etc/hosts
 grep -v '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' /etc/hosts- >> /etc/hosts
 
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "set_hostname_ok") %> || curl <%= callback_url("postinstall", "set_hostname_fail") %>
+send_status "set_hostname"
 
 sed -i 's_<%= config.hanlon_server %>:<%= config.api_port %><%= config.websvc_root %>/image/os/<%= @image_uuid %>_archive.ubuntu.com/ubuntu_g' /etc/apt/sources.list && curl <%= callback_url("postinstall", "sources_fix") %>
 apt-get -y update
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_update_ok") %> || curl <%= callback_url("postinstall", "apt_update_fail") %>
+send_status "apt_update"
 
 apt-get -y upgrade
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_upgrade_ok") %> || curl <%= callback_url("postinstall", "apt_upgrade_fail") %>
+send_status "apt_upgrade"
 
-# Set IP from IP Pool
-echo "auto lo
-iface lo inet loopback
-
-auto eth0
-iface eth0 inet static
-address <%= node_ip_address %>
-netmask <%= @ip_range_subnet %>
-gateway <%= @gateway %>
-" > /etc/network/interfaces &&  curl <%= callback_url("postinstall", "net_set_ip_ok") %> || curl <%= callback_url("postinstall", "net_set_ip_fail") %>
-
-/etc/init.d/networking restart && curl <%= callback_url("postinstall", "net_restart_ok") %> || curl <%= callback_url("postinstall", "net_restart_fail") %>
+sed -i 's/^#\?\s*PermitRootLogin .*$/PermitRootLogin yes/' /etc/ssh/sshd_config && systemctl restart ssh
+send_status "ssh_root_access"
 
 # Get current IP
 default_gw_device=`route | grep default | awk '{print $8}'`
 node_ip=`ifconfig $default_gw_device | grep -w inet | awk -F: '{print $2}' | awk '{print $1}'`
+
 # Send IP up
 curl <%= callback_url("postinstall", "send_ips") %>/$node_ip
+
 # get final script
 curl <%= callback_url("postinstall", "boot") %> | sh
+send_status "final_script"
+
 # Send final state
 curl <%= callback_url("postinstall", "final") %> &

--- a/core/model/ubuntu/precise_ip_pool/os_complete.erb
+++ b/core/model/ubuntu/precise_ip_pool/os_complete.erb
@@ -1,7 +1,21 @@
 #!/bin/bash
+<<<<<<< 545b7d740b5f3f243f684229c9497d0480319653
 echo "Hanlon policy successfully applied" > /tmp/hanlon_complete.log
 echo "Model <%= @label %> - <%= @description %>" >> /tmp/hanlon_complete.log
 echo "Image UUID <%= @image_uuid %>" >> /tmp/hanlon_complete.log
 echo "Node UUID: <%= @node.uuid %>" >> /tmp/hanlon_complete.log
+||||||| merged common ancestors
+echo Hanlon policy successfully applied > /tmp/hanlon_complete.log
+echo Model <%= @label %> - <%= @description %> >> /tmp/hanlon_complete.log
+echo Image UUID <%= @image_uuid %> >> /tmp/hanlon_complete.log
+echo Node UUID: <%= @node.uuid %> >> /tmp/hanlon_complete.log
+=======
+log="/root/hanlon_complete.log"
+
+echo "Hanlon policy successfully applied" > $log
+echo "Model <%= @label %> - <%= @description %>" >> $log
+echo "Image UUID <%= @image_uuid %>" >> $log
+echo "Node UUID: <%= @node.uuid %>" >> $log
+>>>>>>> Created salt broker plugin
 
 sed -i '/hanlon_postinstall/d' /etc/rc.local

--- a/core/model/ubuntu/quantal/os_boot.erb
+++ b/core/model/ubuntu/quantal/os_boot.erb
@@ -1,7 +1,31 @@
 #!/bin/bash
 
+cat <<EOF >/root/os_boot.log
+Postinstall os_boot script log
+==============================
+Hanlon settings:
+    Model <%= @label %> - <%= @description %>
+    Image UUID <%= @image_uuid %>
+    Node UUID: <%= @node.uuid %>
+    Script: $0
+=============================
+
+EOF
+
+function send_status() {
+  status=$?
+  step=$1
+
+  [ "$status" -eq 0 ] && curl <%= callback_url("postinstall", "${step}_ok") %> || curl <%= callback_url("postinstall", "${step}_fail") %>
+}
+
+exec >> /root/os_boot.log
+exec 2>&1
+set -x
+
 hostname <%= hostname %>
 echo <%= hostname %> > /etc/hostname
+sleep 15
 
 # this set of commands should convert the first local (but non-loopback) IP
 # address in the /etc/hosts file to an entry that has the fully-qualified
@@ -14,21 +38,28 @@ grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.
 grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | tail -n +2 >> /etc/hosts
 grep -v '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' /etc/hosts- >> /etc/hosts
 
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "set_hostname_ok") %> || curl <%= callback_url("postinstall", "set_hostname_fail") %>
+send_status "set_hostname"
 
 sed -i 's_<%= config.hanlon_server %>:<%= config.api_port %><%= config.websvc_root %>/image/os/<%= @image_uuid %>_archive.ubuntu.com/ubuntu_g' /etc/apt/sources.list && curl <%= callback_url("postinstall", "sources_fix") %>
 apt-get -y update
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_update_ok") %> || curl <%= callback_url("postinstall", "apt_update_fail") %>
+send_status "apt_update"
 
 apt-get -y upgrade
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_upgrade_ok") %> || curl <%= callback_url("postinstall", "apt_upgrade_fail") %>
+send_status "apt_upgrade"
+
+sed -i 's/^#\?\s*PermitRootLogin .*$/PermitRootLogin yes/' /etc/ssh/sshd_config && systemctl restart ssh
+send_status "ssh_root_access"
 
 # Get current IP
 default_gw_device=`route | grep default | awk '{print $8}'`
 node_ip=`ifconfig $default_gw_device | grep -w inet | awk -F: '{print $2}' | awk '{print $1}'`
+
 # Send IP up
 curl <%= callback_url("postinstall", "send_ips") %>/$node_ip
+
 # get final script
 curl <%= callback_url("postinstall", "boot") %> | sh
+send_status "final_script"
+
 # Send final state
 curl <%= callback_url("postinstall", "final") %> &

--- a/core/model/ubuntu/quantal/os_complete.erb
+++ b/core/model/ubuntu/quantal/os_complete.erb
@@ -1,7 +1,21 @@
 #!/bin/bash
+<<<<<<< 545b7d740b5f3f243f684229c9497d0480319653
 echo "Hanlon policy successfully applied" > /tmp/hanlon_complete.log
 echo "Model <%= @label %> - <%= @description %>" >> /tmp/hanlon_complete.log
 echo "Image UUID <%= @image_uuid %>" >> /tmp/hanlon_complete.log
 echo "Node UUID: <%= @node.uuid %>" >> /tmp/hanlon_complete.log
+||||||| merged common ancestors
+echo Hanlon policy successfully applied > /tmp/hanlon_complete.log
+echo Model <%= @label %> - <%= @description %> >> /tmp/hanlon_complete.log
+echo Image UUID <%= @image_uuid %> >> /tmp/hanlon_complete.log
+echo Node UUID: <%= @node.uuid %> >> /tmp/hanlon_complete.log
+=======
+log="/root/hanlon_complete.log"
+
+echo "Hanlon policy successfully applied" > $log
+echo "Model <%= @label %> - <%= @description %>" >> $log
+echo "Image UUID <%= @image_uuid %>" >> $log
+echo "Node UUID: <%= @node.uuid %>" >> $log
+>>>>>>> Created salt broker plugin
 
 sed -i '/hanlon_postinstall/d' /etc/rc.local

--- a/core/model/ubuntu/raring/os_boot.erb
+++ b/core/model/ubuntu/raring/os_boot.erb
@@ -1,7 +1,31 @@
 #!/bin/bash
 
+cat <<EOF >/root/os_boot.log
+Postinstall os_boot script log
+==============================
+Hanlon settings:
+    Model <%= @label %> - <%= @description %>
+    Image UUID <%= @image_uuid %>
+    Node UUID: <%= @node.uuid %>
+    Script: $0
+=============================
+
+EOF
+
+function send_status() {
+  status=$?
+  step=$1
+
+  [ "$status" -eq 0 ] && curl <%= callback_url("postinstall", "${step}_ok") %> || curl <%= callback_url("postinstall", "${step}_fail") %>
+}
+
+exec >> /root/os_boot.log
+exec 2>&1
+set -x
+
 hostname <%= hostname %>
 echo <%= hostname %> > /etc/hostname
+sleep 15
 
 # this set of commands should convert the first local (but non-loopback) IP
 # address in the /etc/hosts file to an entry that has the fully-qualified
@@ -14,21 +38,28 @@ grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.
 grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | tail -n +2 >> /etc/hosts
 grep -v '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' /etc/hosts- >> /etc/hosts
 
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "set_hostname_ok") %> || curl <%= callback_url("postinstall", "set_hostname_fail") %>
+send_status "set_hostname"
 
 sed -i 's_<%= config.hanlon_server %>:<%= config.api_port %><%= config.websvc_root %>/image/os/<%= @image_uuid %>_archive.ubuntu.com/ubuntu_g' /etc/apt/sources.list && curl <%= callback_url("postinstall", "sources_fix") %>
 apt-get -y update
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_update_ok") %> || curl <%= callback_url("postinstall", "apt_update_fail") %>
+send_status "apt_update"
 
 apt-get -y upgrade
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_upgrade_ok") %> || curl <%= callback_url("postinstall", "apt_upgrade_fail") %>
+send_status "apt_upgrade"
+
+sed -i 's/^#\?\s*PermitRootLogin .*$/PermitRootLogin yes/' /etc/ssh/sshd_config && systemctl restart ssh
+send_status "ssh_root_access"
 
 # Get current IP
 default_gw_device=`route | grep default | awk '{print $8}'`
 node_ip=`ifconfig $default_gw_device | grep -w inet | awk -F: '{print $2}' | awk '{print $1}'`
+
 # Send IP up
 curl <%= callback_url("postinstall", "send_ips") %>/$node_ip
+
 # get final script
 curl <%= callback_url("postinstall", "boot") %> | sh
+send_status "final_script"
+
 # Send final state
 curl <%= callback_url("postinstall", "final") %> &

--- a/core/model/ubuntu/raring/os_complete.erb
+++ b/core/model/ubuntu/raring/os_complete.erb
@@ -1,7 +1,21 @@
 #!/bin/bash
+<<<<<<< 545b7d740b5f3f243f684229c9497d0480319653
 echo "Hanlon policy successfully applied" > /tmp/hanlon_complete.log
 echo "Model <%= @label %> - <%= @description %>" >> /tmp/hanlon_complete.log
 echo "Image UUID <%= @image_uuid %>" >> /tmp/hanlon_complete.log
 echo "Node UUID: <%= @node.uuid %>" >> /tmp/hanlon_complete.log
+||||||| merged common ancestors
+echo Hanlon policy successfully applied > /tmp/hanlon_complete.log
+echo Model <%= @label %> - <%= @description %> >> /tmp/hanlon_complete.log
+echo Image UUID <%= @image_uuid %> >> /tmp/hanlon_complete.log
+echo Node UUID: <%= @node.uuid %> >> /tmp/hanlon_complete.log
+=======
+log="/root/hanlon_complete.log"
+
+echo "Hanlon policy successfully applied" > $log
+echo "Model <%= @label %> - <%= @description %>" >> $log
+echo "Image UUID <%= @image_uuid %>" >> $log
+echo "Node UUID: <%= @node.uuid %>" >> $log
+>>>>>>> Created salt broker plugin
 
 sed -i '/hanlon_postinstall/d' /etc/rc.local

--- a/core/model/ubuntu/trusty/os_boot.erb
+++ b/core/model/ubuntu/trusty/os_boot.erb
@@ -1,7 +1,31 @@
 #!/bin/bash
 
+cat <<EOF >/root/os_boot.log
+Postinstall os_boot script log
+==============================
+Hanlon settings:
+    Model <%= @label %> - <%= @description %>
+    Image UUID <%= @image_uuid %>
+    Node UUID: <%= @node.uuid %>
+    Script: $0
+=============================
+
+EOF
+
+function send_status() {
+  status=$?
+  step=$1
+
+  [ "$status" -eq 0 ] && curl <%= callback_url("postinstall", "${step}_ok") %> || curl <%= callback_url("postinstall", "${step}_fail") %>
+}
+
+exec >> /root/os_boot.log
+exec 2>&1
+set -x
+
 hostname <%= hostname %>
 echo <%= hostname %> > /etc/hostname
+sleep 15
 
 # this set of commands should convert the first local (but non-loopback) IP
 # address in the /etc/hosts file to an entry that has the fully-qualified
@@ -14,21 +38,28 @@ grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.
 grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | tail -n +2 >> /etc/hosts
 grep -v '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' /etc/hosts- >> /etc/hosts
 
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "set_hostname_ok") %> || curl <%= callback_url("postinstall", "set_hostname_fail") %>
+send_status "set_hostname"
 
 sed -i 's_<%= config.hanlon_server %>:<%= config.api_port %><%= config.websvc_root %>/image/os/<%= @image_uuid %>_archive.ubuntu.com/ubuntu_g' /etc/apt/sources.list && curl <%= callback_url("postinstall", "sources_fix") %>
 apt-get -y update
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_update_ok") %> || curl <%= callback_url("postinstall", "apt_update_fail") %>
+send_status "apt_update"
 
 apt-get -y upgrade
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_upgrade_ok") %> || curl <%= callback_url("postinstall", "apt_upgrade_fail") %>
+send_status "apt_upgrade"
+
+sed -i 's/^#\?\s*PermitRootLogin .*$/PermitRootLogin yes/' /etc/ssh/sshd_config && systemctl restart ssh
+send_status "ssh_root_access"
 
 # Get current IP
 default_gw_device=`route | grep default | awk '{print $8}'`
 node_ip=`ifconfig $default_gw_device | grep -w inet | awk -F: '{print $2}' | awk '{print $1}'`
+
 # Send IP up
 curl <%= callback_url("postinstall", "send_ips") %>/$node_ip
+
 # get final script
 curl <%= callback_url("postinstall", "boot") %> | sh
+send_status "final_script"
+
 # Send final state
 curl <%= callback_url("postinstall", "final") %> &

--- a/core/model/ubuntu/trusty/os_complete.erb
+++ b/core/model/ubuntu/trusty/os_complete.erb
@@ -1,7 +1,21 @@
 #!/bin/bash
+<<<<<<< 545b7d740b5f3f243f684229c9497d0480319653
 echo "Hanlon policy successfully applied" > /tmp/hanlon_complete.log
 echo "Model <%= @label %> - <%= @description %>" >> /tmp/hanlon_complete.log
 echo "Image UUID <%= @image_uuid %>" >> /tmp/hanlon_complete.log
 echo "Node UUID: <%= @node.uuid %>" >> /tmp/hanlon_complete.log
+||||||| merged common ancestors
+echo Hanlon policy successfully applied > /tmp/hanlon_complete.log
+echo Model <%= @label %> - <%= @description %> >> /tmp/hanlon_complete.log
+echo Image UUID <%= @image_uuid %> >> /tmp/hanlon_complete.log
+echo Node UUID: <%= @node.uuid %> >> /tmp/hanlon_complete.log
+=======
+log="/root/hanlon_complete.log"
+
+echo "Hanlon policy successfully applied" > $log
+echo "Model <%= @label %> - <%= @description %>" >> $log
+echo "Image UUID <%= @image_uuid %>" >> $log
+echo "Node UUID: <%= @node.uuid %>" >> $log
+>>>>>>> Created salt broker plugin
 
 sed -i '/hanlon_postinstall/d' /etc/rc.local

--- a/core/model/ubuntu/vivid/os_boot.erb
+++ b/core/model/ubuntu/vivid/os_boot.erb
@@ -1,7 +1,31 @@
 #!/bin/bash
 
+cat <<EOF >/root/os_boot.log
+Postinstall os_boot script log
+==============================
+Hanlon settings:
+    Model <%= @label %> - <%= @description %>
+    Image UUID <%= @image_uuid %>
+    Node UUID: <%= @node.uuid %>
+    Script: $0
+=============================
+
+EOF
+
+function send_status() {
+  status=$?
+  step=$1
+
+  [ "$status" -eq 0 ] && curl <%= callback_url("postinstall", "${step}_ok") %> || curl <%= callback_url("postinstall", "${step}_fail") %>
+}
+
+exec >> /root/os_boot.log
+exec 2>&1
+set -x
+
 hostname <%= hostname %>
 echo <%= hostname %> > /etc/hostname
+sleep 15
 
 # this set of commands should convert the first local (but non-loopback) IP
 # address in the /etc/hosts file to an entry that has the fully-qualified
@@ -14,21 +38,28 @@ grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.
 grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | tail -n +2 >> /etc/hosts
 grep -v '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' /etc/hosts- >> /etc/hosts
 
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "set_hostname_ok") %> || curl <%= callback_url("postinstall", "set_hostname_fail") %>
+send_status "set_hostname"
 
 sed -i 's_<%= config.hanlon_server %>:<%= config.api_port %><%= config.websvc_root %>/image/os/<%= @image_uuid %>_archive.ubuntu.com/ubuntu_g' /etc/apt/sources.list && curl <%= callback_url("postinstall", "sources_fix") %>
 apt-get -y update
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_update_ok") %> || curl <%= callback_url("postinstall", "apt_update_fail") %>
+send_status "apt_update"
 
 apt-get -y upgrade
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_upgrade_ok") %> || curl <%= callback_url("postinstall", "apt_upgrade_fail") %>
+send_status "apt_upgrade"
+
+sed -i 's/^#\?\s*PermitRootLogin .*$/PermitRootLogin yes/' /etc/ssh/sshd_config && systemctl restart ssh
+send_status "ssh_root_access"
 
 # Get current IP
 default_gw_device=`route | grep default | awk '{print $8}'`
 node_ip=`ifconfig $default_gw_device | grep -w inet | awk -F: '{print $2}' | awk '{print $1}'`
+
 # Send IP up
 curl <%= callback_url("postinstall", "send_ips") %>/$node_ip
+
 # get final script
 curl <%= callback_url("postinstall", "boot") %> | sh
+send_status "final_script"
+
 # Send final state
 curl <%= callback_url("postinstall", "final") %> &

--- a/core/model/ubuntu/vivid/os_complete.erb
+++ b/core/model/ubuntu/vivid/os_complete.erb
@@ -1,7 +1,21 @@
 #!/bin/bash
+<<<<<<< 545b7d740b5f3f243f684229c9497d0480319653
 echo "Hanlon policy successfully applied" > /tmp/hanlon_complete.log
 echo "Model <%= @label %> - <%= @description %>" >> /tmp/hanlon_complete.log
 echo "Image UUID <%= @image_uuid %>" >> /tmp/hanlon_complete.log
 echo "Node UUID: <%= @node.uuid %>" >> /tmp/hanlon_complete.log
+||||||| merged common ancestors
+echo Hanlon policy successfully applied > /tmp/hanlon_complete.log
+echo Model <%= @label %> - <%= @description %> >> /tmp/hanlon_complete.log
+echo Image UUID <%= @image_uuid %> >> /tmp/hanlon_complete.log
+echo Node UUID: <%= @node.uuid %> >> /tmp/hanlon_complete.log
+=======
+log="/root/hanlon_complete.log"
+
+echo "Hanlon policy successfully applied" > $log
+echo "Model <%= @label %> - <%= @description %>" >> $log
+echo "Image UUID <%= @image_uuid %>" >> $log
+echo "Node UUID: <%= @node.uuid %>" >> $log
+>>>>>>> Created salt broker plugin
 
 sed -i '/hanlon_postinstall/d' /etc/rc.local

--- a/core/model/ubuntu/xenial/os_boot.erb
+++ b/core/model/ubuntu/xenial/os_boot.erb
@@ -1,7 +1,31 @@
 #!/bin/bash
 
+cat <<EOF >/root/os_boot.log
+Postinstall os_boot script log
+==============================
+Hanlon settings:
+    Model <%= @label %> - <%= @description %>
+    Image UUID <%= @image_uuid %>
+    Node UUID: <%= @node.uuid %>
+    Script: $0
+=============================
+
+EOF
+
+function send_status() {
+  status=$?
+  step=$1
+
+  [ "$status" -eq 0 ] && curl <%= callback_url("postinstall", "${step}_ok") %> || curl <%= callback_url("postinstall", "${step}_fail") %>
+}
+
+exec >> /root/os_boot.log
+exec 2>&1
+set -x
+
 hostname <%= hostname %>
 echo <%= hostname %> > /etc/hostname
+sleep 15
 
 # this set of commands should convert the first local (but non-loopback) IP
 # address in the /etc/hosts file to an entry that has the fully-qualified
@@ -14,21 +38,28 @@ grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.
 grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | tail -n +2 >> /etc/hosts
 grep -v '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' /etc/hosts- >> /etc/hosts
 
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "set_hostname_ok") %> || curl <%= callback_url("postinstall", "set_hostname_fail") %>
+send_status "set_hostname"
 
 sed -i 's_<%= config.hanlon_server %>:<%= config.api_port %><%= config.websvc_root %>/image/os/<%= @image_uuid %>_archive.ubuntu.com/ubuntu_g' /etc/apt/sources.list && curl <%= callback_url("postinstall", "sources_fix") %>
 apt-get -y update
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_update_ok") %> || curl <%= callback_url("postinstall", "apt_update_fail") %>
+send_status "apt_update"
 
 apt-get -y upgrade
-[ "$?" -eq 0 ] && curl <%= callback_url("postinstall", "apt_upgrade_ok") %> || curl <%= callback_url("postinstall", "apt_upgrade_fail") %>
+send_status "apt_upgrade"
+
+sed -i 's/^#\?\s*PermitRootLogin .*$/PermitRootLogin yes/' /etc/ssh/sshd_config && systemctl restart ssh
+send_status "ssh_root_access"
 
 # Get current IP
 default_gw_device=`route | grep default | awk '{print $8}'`
 node_ip=`ifconfig $default_gw_device | grep -w inet | awk -F: '{print $2}' | awk '{print $1}'`
+
 # Send IP up
 curl <%= callback_url("postinstall", "send_ips") %>/$node_ip
+
 # get final script
 curl <%= callback_url("postinstall", "boot") %> | sh
+send_status "final_script"
+
 # Send final state
 curl <%= callback_url("postinstall", "final") %> &

--- a/core/model/ubuntu/xenial/os_complete.erb
+++ b/core/model/ubuntu/xenial/os_complete.erb
@@ -1,7 +1,21 @@
 #!/bin/bash
+<<<<<<< 545b7d740b5f3f243f684229c9497d0480319653
 echo "Hanlon policy successfully applied" > /tmp/hanlon_complete.log
 echo "Model <%= @label %> - <%= @description %>" >> /tmp/hanlon_complete.log
 echo "Image UUID <%= @image_uuid %>" >> /tmp/hanlon_complete.log
 echo "Node UUID: <%= @node.uuid %>" >> /tmp/hanlon_complete.log
+||||||| merged common ancestors
+echo Hanlon policy successfully applied > /tmp/hanlon_complete.log
+echo Model <%= @label %> - <%= @description %> >> /tmp/hanlon_complete.log
+echo Image UUID <%= @image_uuid %> >> /tmp/hanlon_complete.log
+echo Node UUID: <%= @node.uuid %> >> /tmp/hanlon_complete.log
+=======
+log="/root/hanlon_complete.log"
+
+echo "Hanlon policy successfully applied" > $log
+echo "Model <%= @label %> - <%= @description %>" >> $log
+echo "Image UUID <%= @image_uuid %>" >> $log
+echo "Node UUID: <%= @node.uuid %>" >> $log
+>>>>>>> Created salt broker plugin
 
 sed -i '/hanlon_postinstall/d' /etc/rc.local


### PR DESCRIPTION
Here is the completed Salt broker that I started a few months back. Finally had time to tidy it up. 

It is based off the Puppet plugin. I have also rewritten how os_boot.erb is structured (at least in the Ubuntu OSes) to provide more logging/debug information. All the logs are now written to /root so that they survive any cleanups that may occur in /tmp. Part of this is so that one can go back and investigate the lineage of the OS install and/or look for installation errors. 

Another change to the code outside of the Salt plugin proper was updating os_boot.erb to delay after setting the hostname. While debugging why on some systems the os_boot script would complete successfully while on others it would act as if it was disconnected from the network, I found that some NIC drivers need a few seconds to reinitialize the chipset and come back up on the network. I have added a sleep after setting the hostname to allow the network to settle. 15 seconds is almost certainly too long but in comparison of the OS install, it is a pretty minor increase of the overall time. In reality this could probably be 5 seconds and not cause any problems. 

* Created salt broker plugin
* Added salt broker to included brokers
* Fixed additional references to puppet scripts
* Added enhanced logging and moved logs to /root for post install inspection
* Fixed install of correct salt version and more testing during install
* Stopped using Hanlon ID in favor of FQDN
* Added sleep after setting hostname to allow some NICs to reset
* Updated os_boot.erb in newer Ubuntu versions
* Updated os_complete.erb in newer Ubuntu versions for better logging
* Minor clean up of salt.rb, removing last puppet references